### PR TITLE
Add Codecov.io integration (fix #52)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         make setup
     - name: Check coverage
       run: make coverage
+    - name: Upload coverage report to codecov.io
+      uses: codecov/codecov-action@v1
 
   run_benchmark:
     name: Run benchmark

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![image](https://img.shields.io/pypi/v/pyserde.svg)](https://pypi.org/project/pyserde/)
 [![image](https://img.shields.io/pypi/pyversions/pyserde.svg)](https://pypi.org/project/pyserde/)
 ![Tests](https://github.com/yukinarit/pyserde/workflows/Tests/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/yukinarit/pyserde/badge.svg?branch=master)](https://coveralls.io/github/yukinarit/pyserde?branch=master)
+[![codecov](https://codecov.io/gh/yukinarit/pyserde/branch/master/graph/badge.svg)](https://codecov.io/gh/yukinarit/pyserde)
 
 Yet another serialization library on top of [dataclasses](https://docs.python.org/3/library/dataclasses.html).
 


### PR DESCRIPTION
A fairly simple modification for tracking coverage :-) Be sure to sign up on Codecov.io before merging this PR for proper functioning.