### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,15 @@ jobs:
        uses: actions/setup-python@v2
        with:
          python-version: 3.7
+     - name: Restore pip cache
+       uses: actions/cache@v2
+       with:
+         path: ${{ env.pythonLocation }}
+         key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
      - name: Install dependencies
        run: |
          pip install pipenv
-         make setup
+         pipenv install --skip-lock --system --dev
      - name: Get PR number
        uses: jwalton/gh-find-current-pr@v1
        id: findPr
@@ -39,7 +44,10 @@ jobs:
        env:
          PR: ${{ steps.findPr.outputs.pr }}
      - name: Build docs
-       run: make docs
+       run: |
+         mkdir -p docs
+         pdoc serde --html -o html --force
+         cp -f html/serde/* docs/
      - name: Deploy on gh-pages
        uses: JamesIves/github-pages-deploy-action@3.7.1
        with:
@@ -48,4 +56,3 @@ jobs:
          FOLDER: docs
          COMMIT_MESSAGE: ${{ env.COMMIT_MESSAGE }}
          CLEAN: true
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,23 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Restore pip cache
+      # Caching on Windows is turned off due to inconsistent behaviour
+      if: matrix.os != 'windows-latest'
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ matrix.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
     - name: Install dependencies
       run: |
         pip install pipenv
-        pipenv install --dev --skip-lock --python ${{ matrix.python-version }}
-        pipenv run pip list
-        pushd examples && pipenv install --dev --python ${{ matrix.python-version }} && popd
+        pipenv install --skip-lock --system --dev
+        pip list
+        cd examples && pipenv install --skip-lock --system --dev
     - name: Run tests
-      run: make test examples
+      run: |
+        pytest tests --doctest-modules serde -v
+        cd examples && python runner.py
 
   check_coverage:
     name: Check coverage
@@ -38,12 +47,17 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
     - name: Install dependencies
       run: |
         pip install pipenv
-        make setup
+        pipenv install --skip-lock --system --dev
     - name: Check coverage
-      run: make coverage
+      run: pytest tests --doctest-modules serde -v --cov=serde --cov-report term --cov-report xml
     - name: Upload coverage report to codecov.io
       uses: codecov/codecov-action@v1
 
@@ -58,9 +72,15 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
     - name: Install dependencies
       run: |
         pip install pipenv
-        make setup setup-bench
+        cd bench && pipenv install --skip-lock --system
     - name: Run benchmark
-      run: make bench
+      run: |
+        python bench/bench.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9-dev, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   test:
-    name: Run tests with Python [${{ matrix.python-version }}] on ${{ matrix.os }}
+    name: Python [${{ matrix.python-version }}] on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pipenv
-        make setup
+        pipenv install --dev --skip-lock --python ${{ matrix.python-version }}
+        pipenv run pip list
+        pushd examples && pipenv install --dev --python ${{ matrix.python-version }} && popd
     - name: Run tests
       run: make test examples
 


### PR DESCRIPTION
### 1. Explicitly pass Python version to pipenv (fix #67)
It looks like `pipenv` doesn't use default Python version on Windows and MacOS so I've decided to unfold your `make setup` statement for explicitly passing correct Python version to `pipenv`. You can check GitHub Action logs here https://github.com/alexmisk/pyserde/actions/runs/366167153 if needed.

This is still a workaround though. GitHub Actions workers are virtual environments *per se*, and using `pipenv` for creating another environment inside them seems like an overkill :-) One of the major downsides of `pipenv` inside CI is inability to deal with dependency caching effectively (which slows down CI workflow execution time).

### 2. Rename testing step for better readability
![ci](https://user-images.githubusercontent.com/4103218/99268823-b5e59880-2836-11eb-9656-fc7e7b71b195.png)
Now one can see Python version and OS at the same time :-)

### 3. Change Python 3.9-dev to 3.9 in test matrix
Python 3.9 was released about a month ago, no need to use dev version anymore.

---
**P.S.** Note that benchmark step is still failing.