### PR TITLE
Support bare dict, list and tuple

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,6 @@ flake8 = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-watch = "*"
-python-coveralls = "*"
 coverage = "==4.5.4"
 pdoc3 = "~=0.8"
 mypy = {version = "==0.782",markers = "platform_python_implementation!='PyPy'"}

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -179,6 +179,19 @@ def is_tuple(typ) -> bool:
         return isinstance(typ, tuple)
 
 
+def is_bare_tuple(typ) -> bool:
+    """
+    Test if the type is `typing.Tuple` without type args.
+
+    >>> from typing import Tuple
+    >>> is_bare_tuple(Tuple[int, str])
+    False
+    >>> is_bare_tuple(Tuple)
+    True
+    """
+    return is_tuple(typ) and typ is Tuple
+
+
 def is_dict(typ) -> bool:
     """
     Test if the type is `typing.Dict`.

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -19,7 +19,7 @@ def get_origin(typ):
     Provide `get_origin` that works in python >= 3.6.
     """
     try:
-        return typing.get_origin(typ)
+        return typing.get_origin(typ)  # python>=3.8 typing module has get_args.
     except AttributeError:
         return typing_inspect.get_origin(typ)
 
@@ -71,7 +71,7 @@ def type_args(typ):
         else:
             return args
     except AttributeError:
-        return typing.get_args(typ)
+        return typing.get_args(typ)  # python>=3.8 typing module has get_args.
 
 
 def union_args(typ: Union) -> Tuple:
@@ -143,11 +143,30 @@ def is_opt(typ) -> bool:
 def is_list(typ) -> bool:
     """
     Test if the type is `typing.List`.
+
+    >>> from typing import List
+    >>> is_list(List[int])
+    True
+    >>> is_list(List)
+    True
     """
     try:
         return issubclass(get_origin(typ), list)
     except TypeError:
         return isinstance(typ, list)
+
+
+def is_bare_list(typ) -> bool:
+    """
+    Test if the type is `typing.List` without type args.
+
+    >>> from typing import List
+    >>> is_bare_list(List[int])
+    False
+    >>> is_bare_list(List)
+    True
+    """
+    return is_list(typ) and typ is List
 
 
 def is_tuple(typ) -> bool:
@@ -178,7 +197,7 @@ def is_dict(typ) -> bool:
 
 def is_bare_dict(typ) -> bool:
     """
-    Test if the type is bare `typing.Dict`.
+    Test if the type is `typing.Dict` without type args.
 
     >>> from typing import Dict
     >>> is_bare_dict(Dict[int, str])

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -3,11 +3,12 @@ Module for compatibility.
 """
 import dataclasses
 import enum
-import typing_inspect
 import typing
 from dataclasses import fields, is_dataclass
 from itertools import zip_longest
-from typing import Iterator, List, Optional, Tuple, Type, TypeVar, Union, Dict
+from typing import Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union
+
+import typing_inspect
 
 __all__: List = []
 

--- a/serde/de.py
+++ b/serde/de.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Type
 import jinja2
 
 from .compat import (has_default, has_default_factory, is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple,
-                     is_union, iter_types, type_args, is_bare_dict, is_bare_list)
+                     is_union, iter_types, type_args, is_bare_dict, is_bare_list, is_bare_tuple)
 from .core import FROM_DICT, FROM_ITER, HIDDEN_NAME, SETTINGS, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import deserialize as custom
 
@@ -403,11 +403,14 @@ class Renderer:
         >>> Renderer('foo').render(field)
         '(data[0][0], data[0][1], [v for v in data[0][2]], Foo.foo(data[0][3]))'
         """
-        values = []
-        for i, typ in enumerate(type_args(arg.type)):
-            inner = arg[i]
-            values.append(self.render(inner))
-        return f'({", ".join(values)})'
+        if is_bare_tuple(arg.type):
+            return f'tuple({arg.data})'
+        else:
+            values = []
+            for i, typ in enumerate(type_args(arg.type)):
+                inner = arg[i]
+                values.append(self.render(inner))
+            return f'({", ".join(values)})'
 
     def dict(self, arg: DeField) -> str:
         """

--- a/serde/de.py
+++ b/serde/de.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Type
 import jinja2
 
 from .compat import (has_default, has_default_factory, is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple,
-                     is_union, iter_types, type_args, is_bare_dict)
+                     is_union, iter_types, type_args, is_bare_dict, is_bare_list)
 from .core import FROM_DICT, FROM_ITER, HIDDEN_NAME, SETTINGS, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import deserialize as custom
 
@@ -383,7 +383,10 @@ class Renderer:
         >>> Renderer('foo').render(DeField(List[List[int]], 'l', datavar='data'))
         '[[v for v in v] for v in data["l"]]'
         """
-        return f'[{self.render(arg[0])} for v in {arg.data}]'
+        if is_bare_list(arg.type):
+            return f'list({arg.data})'
+        else:
+            return f'[{self.render(arg[0])} for v in {arg.data}]'
 
     def tuple(self, arg: DeField) -> str:
         """

--- a/serde/de.py
+++ b/serde/de.py
@@ -19,8 +19,8 @@ from typing import Any, Callable, Dict, List, Optional, Type
 
 import jinja2
 
-from .compat import (has_default, has_default_factory, is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple,
-                     is_union, iter_types, type_args, is_bare_dict, is_bare_list, is_bare_tuple)
+from .compat import (has_default, has_default_factory, is_bare_dict, is_bare_list, is_bare_tuple, is_dict, is_enum,
+                     is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args)
 from .core import FROM_DICT, FROM_ITER, HIDDEN_NAME, SETTINGS, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import deserialize as custom
 

--- a/serde/de.py
+++ b/serde/de.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Type
 import jinja2
 
 from .compat import (has_default, has_default_factory, is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple,
-                     is_union, iter_types, type_args)
+                     is_union, iter_types, type_args, is_bare_dict)
 from .core import FROM_DICT, FROM_ITER, HIDDEN_NAME, SETTINGS, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import deserialize as custom
 
@@ -420,9 +420,12 @@ class Renderer:
         >>> Renderer('foo').render(DeField(Dict[Foo, List[Foo]], 'f', datavar='data'))
         '{Foo.foo(k): [Foo.foo(v) for v in v] for k, v in data["f"].items()}'
         """
-        k = arg.key_field()
-        v = arg.value_field()
-        return f'{{{self.render(k)}: {self.render(v)} for k, v in {arg.data}.items()}}'
+        if is_bare_dict(arg.type):
+            return arg.data
+        else:
+            k = arg.key_field()
+            v = arg.value_field()
+            return f'{{{self.render(k)}: {self.render(v)} for k, v in {arg.data}.items()}}'
 
     def enum(self, arg: DeField) -> str:
         return f'{arg.type.__name__}({self.primitive(arg)})'

--- a/serde/se.py
+++ b/serde/se.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import jinja2
 
-from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args
+from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict
 from .core import (HIDDEN_NAME, SE_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen,
                    logger)
 from .more_types import serialize as custom
@@ -382,11 +382,14 @@ class Renderer:
         """
         Render rvalue for dict.
         """
-        karg = arg[0]
-        karg.name = 'k'
-        varg = arg[1]
-        varg.name = 'v'
-        return f'{{{self.render(karg)}: {self.render(varg)} for k, v in {arg.varname}.items()}}'
+        if is_bare_dict(arg.type):
+            return arg.varname
+        else:
+            karg = arg[0]
+            karg.name = 'k'
+            varg = arg[1]
+            varg.name = 'v'
+            return f'{{{self.render(karg)}: {self.render(varg)} for k, v in {arg.varname}.items()}}'
 
     def enum(self, arg: SeField) -> str:
         return f'__serde_enum_value__({arg.type.__name__}, {arg.varname})'

--- a/serde/se.py
+++ b/serde/se.py
@@ -11,7 +11,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import jinja2
 
-from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict, is_bare_list, is_bare_tuple
+from .compat import (is_bare_dict, is_bare_list, is_bare_tuple, is_dict, is_enum, is_list, is_opt, is_primitive,
+                     is_tuple, is_union, iter_types, type_args)
 from .core import (HIDDEN_NAME, SE_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen,
                    logger)
 from .more_types import serialize as custom

--- a/serde/se.py
+++ b/serde/se.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import jinja2
 
-from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict
+from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict, is_bare_list
 from .core import (HIDDEN_NAME, SE_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen,
                    logger)
 from .more_types import serialize as custom
@@ -363,9 +363,12 @@ class Renderer:
         """
         Render rvalue for list.
         """
-        earg = arg[0]
-        earg.name = 'v'
-        return f'[{self.render(earg)} for v in {arg.varname}]'
+        if is_bare_list(arg.type):
+            return arg.varname
+        else:
+            earg = arg[0]
+            earg.name = 'v'
+            return f'[{self.render(earg)} for v in {arg.varname}]'
 
     def tuple(self, arg: SeField) -> str:
         """

--- a/serde/se.py
+++ b/serde/se.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import jinja2
 
-from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict, is_bare_list
+from .compat import is_dict, is_enum, is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_bare_dict, is_bare_list, is_bare_tuple
 from .core import (HIDDEN_NAME, SE_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen,
                    logger)
 from .more_types import serialize as custom
@@ -374,12 +374,15 @@ class Renderer:
         """
         Render rvalue for tuple.
         """
-        rvalues = []
-        for i, _ in enumerate(type_args(arg.type)):
-            r = arg[i]
-            r.name = f'{arg.varname}[{i}]'
-            rvalues.append(self.render(r))
-        return f"({', '.join(rvalues)})"
+        if is_bare_tuple(arg.type):
+            return arg.varname
+        else:
+            rvalues = []
+            for i, _ in enumerate(type_args(arg.type)):
+                r = arg[i]
+                r.name = f'{arg.varname}[{i}]'
+                rvalues.append(self.render(r))
+            return f"({', '.join(rvalues)})"
 
     def dict(self, arg: SeField) -> str:
         """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -109,6 +109,40 @@ def test_forward_declaration():
 
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
+def test_dict(se, de, opt):
+
+    @deserialize(**opt)
+    @serialize(**opt)
+    @dataclass
+    class PriDict:
+        i: Dict[int, int]
+        s: Dict[str, str]
+        f: Dict[float, float]
+        b: Dict[bool, bool]
+
+    if se in (to_json, to_msgpack, to_toml):
+        # JSON, Msgpack, Toml don't allow non string key.
+        p = PriDict({'10': 10}, {'foo': 'bar'}, {'100.0': 100.0}, {'True': False})
+        assert p == de(PriDict, se(p))
+    else:
+        p = PriDict({10: 10}, {'foo': 'bar'}, {100.0: 100.0}, {True: False})
+        assert p == de(PriDict, se(p))
+
+    @deserialize(**opt)
+    @serialize(**opt)
+    @dataclass
+    class BareDict:
+        d: Dict
+
+    p = BareDict({'10': 10})
+    assert p == de(BareDict, se(p))
+
+    p = BareDict({'10': 10, 'foo': 'bar', '100.0': 100.0, 'True': False})
+    assert p == de(BareDict, se(p))
+
+
+@pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize('se,de', all_formats)
 def test_enum(se, de, opt):
     from .data import E, IE
     from serde.compat import is_enum

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,5 @@
 import dataclasses
 import enum
-import json
 import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
@@ -15,8 +14,7 @@ from serde.toml import from_toml, to_toml
 from serde.yaml import from_yaml, to_yaml
 
 from . import data
-from .data import (Bool, Float, Int, ListPri, NestedPri, NestedPriOpt, NestedPriTuple, Pri, PriDefault, PriOpt,
-                   PriTuple, Str)
+from .data import Bool, Float, Int, ListPri, NestedPri, NestedPriOpt, Pri, PriDefault, PriOpt, Str
 
 log = logging.getLogger('test')
 
@@ -110,7 +108,6 @@ def test_forward_declaration():
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
 def test_list(se, de, opt):
-
     @deserialize(**opt)
     @serialize(**opt)
     @dataclass
@@ -141,7 +138,6 @@ def test_list(se, de, opt):
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
 def test_dict(se, de, opt):
-
     @deserialize(**opt)
     @serialize(**opt)
     @dataclass
@@ -230,7 +226,6 @@ def test_enum_imported(se, de):
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
 def test_tuple(se, de, opt):
-
     @deserialize(**opt)
     @serialize(**opt)
     @dataclass
@@ -240,15 +235,11 @@ def test_tuple(se, de, opt):
         f: Tuple[float, float]
         b: Tuple[bool, bool]
 
-    p = Homogeneous(
-        (10, 20), ('a', 'b'), (10.0, 20.0), (True, False)
-    )
+    p = Homogeneous((10, 20), ('a', 'b'), (10.0, 20.0), (True, False))
     assert p == de(Homogeneous, se(p))
 
     # List can also be used.
-    p = Homogeneous(
-        [10, 20], ['a', 'b'], [10.0, 20.0], [True, False]
-    )
+    p = Homogeneous([10, 20], ['a', 'b'], [10.0, 20.0], [True, False])
     assert p != de(Homogeneous, se(p))
 
     @deserialize(**opt)
@@ -259,9 +250,7 @@ def test_tuple(se, de, opt):
 
     # Toml doesn't support variant type of array.
     if se is not to_toml:
-        p = Variant(
-            (10, 'a', 10.0, True)
-        )
+        p = Variant((10, 'a', 10.0, True))
         assert p == de(Variant, se(p))
 
     @deserialize(**opt)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -109,6 +109,37 @@ def test_forward_declaration():
 
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
+def test_list(se, de, opt):
+
+    @deserialize(**opt)
+    @serialize(**opt)
+    @dataclass
+    class PriList:
+        i: List[int]
+        s: List[str]
+        f: List[float]
+        b: List[bool]
+
+    p = PriList([10, 10], ['foo', 'bar'], [10.0, 10.0], [True, False])
+    assert p == de(PriList, se(p))
+
+    @deserialize(**opt)
+    @serialize(**opt)
+    @dataclass
+    class BareList:
+        i: List
+
+    p = BareList([10])
+    assert p == de(BareList, se(p))
+
+    # List can contain different types (except Toml).
+    if se is not to_toml:
+        p = BareList([10, 'foo', 10.0, True])
+        assert p == de(BareList, se(p))
+
+
+@pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize('se,de', all_formats)
 def test_dict(se, de, opt):
 
     @deserialize(**opt)


### PR DESCRIPTION
Close #63 

Now supports bare form of dict, list and tuple like this.

```python
@dataclass
class Foo:
    items: Dict
    list: List
    params: Tuple
```