### PR TITLE
Add support for Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ That's it! pyserde offers many more features. If you're interested, please read 
 ## Supported types
 
 * Primitives (int, float, str, bool)
-* Containers (List, Tuple, Dict)
+* Containers (List, Set, Tuple, Dict)
 * [`Optional`](https://docs.python.org/3/library/typing.html#typing.Optional)
 * User defined class with [`@dataclass`](https://docs.python.org/3/library/dataclasses.html)
 * [Enum](https://docs.python.org/3/library/enum.html#enum.Enum) and [IntEnum](https://docs.python.org/3/library/enum.html#enum.IntEnum)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-codestyle_ignore = E252

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -6,7 +6,7 @@ import enum
 import typing
 from dataclasses import fields, is_dataclass
 from itertools import zip_longest
-from typing import Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union, Set
 
 import typing_inspect
 
@@ -37,7 +37,7 @@ def get_args(typ):
 
 def typename(typ) -> str:
     """
-    >>> from typing import List, Dict
+    >>> from typing import List, Dict, Set
     >>> typename(int)
     'int'
     >>> class Foo: pass
@@ -53,6 +53,8 @@ def typename(typ) -> str:
     'Optional[List[Foo]]'
     >>> typename(Union[Optional[Foo], List[Foo], Union[str, int]])
     'Union[Optional[Foo], List[Foo], str, int]'
+    >>> typename(Set[Foo])
+    'Set[Foo]'
     """
     if is_opt(typ):
         return f'Optional[{typename(type_args(typ)[0])}]'
@@ -65,6 +67,13 @@ def typename(typ) -> str:
             return f'List[{et}]'
         else:
             return 'List'
+    elif is_set(typ):
+        args = type_args(typ)
+        if args:
+            et = typename(args[0])
+            return f'Set[{et}]'
+        else:
+            return 'Set'
     elif is_dict(typ):
         args = type_args(typ)
         if args and len(args) == 2:
@@ -128,7 +137,7 @@ def iter_types(cls: Type) -> Iterator[Type]:
     elif is_union(cls):
         for arg in type_args(cls):
             yield from iter_types(arg)
-    elif is_list(cls):
+    elif is_list(cls) or is_set(cls):
         arg = type_args(cls)
         if arg:
             yield from iter_types(arg[0])
@@ -209,6 +218,35 @@ def is_bare_tuple(typ) -> bool:
     True
     """
     return is_tuple(typ) and typ in (Tuple, tuple)
+
+
+def is_set(typ) -> bool:
+    """
+    Test if the type is `typing.Set`.
+
+    >>> from typing import Set
+    >>> is_set(Set[int])
+    True
+    >>> is_set(Set)
+    True
+    """
+    try:
+        return issubclass(get_origin(typ), set)
+    except TypeError:
+        return typ in (Set, set)
+
+
+def is_bare_set(typ) -> bool:
+    """
+    Test if the type is `typing.Set` without type args.
+
+    >>> from typing import Set
+    >>> is_bare_set(Set[int])
+    False
+    >>> is_bare_set(Set)
+    True
+    """
+    return is_set(typ) and typ in (Set, set)
 
 
 def is_dict(typ) -> bool:

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -6,7 +6,7 @@ import enum
 import typing
 from dataclasses import fields, is_dataclass
 from itertools import zip_longest
-from typing import Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union, Set
+from typing import Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 import typing_inspect
 

--- a/serde/core.py
+++ b/serde/core.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar
 
 import stringcase
 
-from .compat import T, assert_type, is_dict, is_list, is_opt, is_tuple, is_union, type_args, is_set
+from .compat import T, assert_type, is_dict, is_list, is_opt, is_set, is_tuple, is_union, type_args
 
 __all__: List = []
 

--- a/serde/core.py
+++ b/serde/core.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar
 
 import stringcase
 
-from .compat import T, assert_type, is_dict, is_list, is_opt, is_tuple, is_union, type_args
+from .compat import T, assert_type, is_dict, is_list, is_opt, is_tuple, is_union, type_args, is_set
 
 __all__: List = []
 
@@ -103,6 +103,12 @@ def typecheck(cls: Type[T], obj: T) -> None:
     elif is_list(cls):
         assert_type(list, obj)
         if isinstance(obj, list):
+            typ = type_args(cls)[0]
+            for e in obj:
+                typecheck(typ, e)
+    elif is_set(cls):
+        assert_type(set, obj)
+        if isinstance(obj, set):
             typ = type_args(cls)[0]
             for e in obj:
                 typecheck(typ, e)

--- a/serde/de.py
+++ b/serde/de.py
@@ -25,8 +25,8 @@ from uuid import UUID
 
 import jinja2
 
-from .compat import (has_default, has_default_factory, is_bare_dict, is_bare_list, is_bare_tuple, is_dict, is_enum,
-                     is_list, is_opt, is_primitive, is_tuple, is_union, iter_types, type_args, is_set, is_bare_set)
+from .compat import (has_default, has_default_factory, is_bare_dict, is_bare_list, is_bare_set, is_bare_tuple, is_dict,
+                     is_enum, is_list, is_opt, is_primitive, is_set, is_tuple, is_union, iter_types, type_args)
 from .core import FROM_DICT, FROM_ITER, HIDDEN_NAME, SETTINGS, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import deserialize as custom
 from .py36_datetime_compat import py36_date_fromisoformat, py36_datetime_fromisoformat

--- a/serde/json.py
+++ b/serde/json.py
@@ -22,7 +22,7 @@ class JsonDeserializer(Deserializer):
 
 
 def to_json(obj: Any, se: Serializer = JsonSerializer, **opts) -> str:
-    return se.serialize(to_dict(obj, reuse_instances=False), **opts)
+    return se.serialize(to_dict(obj, reuse_instances=False, convert_sets=True), **opts)
 
 
 def from_json(c: Type[T], s: str, de: Deserializer = JsonDeserializer, **opts) -> T:

--- a/serde/msgpack.py
+++ b/serde/msgpack.py
@@ -41,7 +41,7 @@ def to_msgpack(
             raise SerdeError(f"Could not find type code for {obj_type.__name__} in ext_dict")
 
     to_func = to_dict if named else to_tuple
-    return se.serialize(to_func(obj, reuse_instances=False), ext_type_code=ext_type_code, **opts)
+    return se.serialize(to_func(obj, reuse_instances=False, convert_sets=True), ext_type_code=ext_type_code, **opts)
 
 
 def from_msgpack(

--- a/serde/se.py
+++ b/serde/se.py
@@ -97,8 +97,8 @@ def serialize(_cls=None, rename_all: Optional[str] = None, reuse_instances_defau
         g['is_dataclass'] = is_dataclass
         g['__custom_serializer__'] = custom
         g['__serde_enum_value__'] = enum_value
-        cls = se_func(cls, TO_ITER, render_astuple(cls, reuse_instances_default, custom), g)
-        cls = se_func(cls, TO_DICT, render_asdict(cls, rename_all, reuse_instances_default, custom), g)
+        cls = se_func(cls, TO_ITER, render_to_tuple(cls, reuse_instances_default, custom), g)
+        cls = se_func(cls, TO_DICT, render_to_dict(cls, rename_all, reuse_instances_default, custom), g)
         return cls
 
     if _cls is None:
@@ -240,7 +240,7 @@ def to_arg(f: SeField) -> SeField:
     return f
 
 
-def render_astuple(cls: Type, reuse_instances_default: bool = True, custom: Custom = None) -> str:
+def render_to_tuple(cls: Type, reuse_instances_default: bool = True, custom: Custom = None) -> str:
     template = """
 def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
   if reuse_instances is Ellipsis:
@@ -274,7 +274,7 @@ def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
     return env.get_template('iter').render(func=TO_ITER, cls=cls, reuse_instances_default=reuse_instances_default)
 
 
-def render_asdict(
+def render_to_dict(
     cls: Type, case: Optional[str] = None, reuse_instances_default: bool = True, custom: Custom = None
 ) -> str:
     template = """

--- a/serde/se.py
+++ b/serde/se.py
@@ -16,9 +16,9 @@ from uuid import UUID
 
 import jinja2
 
-from .compat import (is_bare_dict, is_bare_list, is_bare_tuple, is_dict, is_enum, is_list, is_opt, is_primitive,
-                     is_tuple, is_union, iter_types, type_args, is_set, is_bare_set)
-from .core import (HIDDEN_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen, logger)
+from .compat import (is_bare_dict, is_bare_list, is_bare_set, is_bare_tuple, is_dict, is_enum, is_list, is_opt,
+                     is_primitive, is_set, is_tuple, is_union, iter_types, type_args)
+from .core import HIDDEN_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen, logger
 from .more_types import serialize as custom
 
 __all__: List = ['serialize', 'is_serializable', 'Serializer', 'to_tuple', 'to_dict']
@@ -38,7 +38,12 @@ class Serializer(metaclass=abc.ABCMeta):
         pass
 
 
-def serialize(_cls=None, rename_all: Optional[str] = None, reuse_instances_default: bool = True, convert_sets_default: bool = False):
+def serialize(
+    _cls=None,
+    rename_all: Optional[str] = None,
+    reuse_instances_default: bool = True,
+    convert_sets_default: bool = False,
+):
     """
     `serialize` decorator. A dataclass with this decorator can be serialized
     into an object in various data format such as JSON and MsgPack.
@@ -243,10 +248,9 @@ def to_arg(f: SeField) -> SeField:
     return f
 
 
-def render_to_tuple(cls: Type,
-                   reuse_instances_default: bool = True,
-                   convert_sets_default: bool = False,
-                   custom: Custom = None) -> str:
+def render_to_tuple(
+    cls: Type, reuse_instances_default: bool = True, convert_sets_default: bool = False, custom: Custom = None
+) -> str:
     template = """
 def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = {{convert_sets_default}}):
   if reuse_instances is Ellipsis:
@@ -279,16 +283,21 @@ def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = 
     env.filters.update({'is_dataclass': is_dataclass})
     env.filters.update({'rvalue': renderer.render})
     env.filters.update({'arg': to_arg})
-    return env.get_template('iter').render(func=TO_ITER, cls=cls,
-                                           reuse_instances_default=reuse_instances_default,
-                                           convert_sets_default=convert_sets_default)
+    return env.get_template('iter').render(
+        func=TO_ITER,
+        cls=cls,
+        reuse_instances_default=reuse_instances_default,
+        convert_sets_default=convert_sets_default,
+    )
 
 
 def render_to_dict(
-        cls: Type, case: Optional[str] = None,
-        reuse_instances_default: bool = True,
-        convert_sets_default: bool = False,
-        custom: Custom = None) -> str:
+    cls: Type,
+    case: Optional[str] = None,
+    reuse_instances_default: bool = True,
+    convert_sets_default: bool = False,
+    custom: Custom = None,
+) -> str:
     template = """
 def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = {{convert_sets_default}}):
   if reuse_instances is Ellipsis:
@@ -328,9 +337,12 @@ def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = 
     env.filters.update({'rvalue': renderer.render})
     env.filters.update({'arg': to_arg})
     env.filters.update({'case': functools.partial(conv, case=case)})
-    return env.get_template('dict').render(func=TO_DICT, cls=cls,
-                                           reuse_instances_default=reuse_instances_default,
-                                           convert_sets_default=convert_sets_default)
+    return env.get_template('dict').render(
+        func=TO_DICT,
+        cls=cls,
+        reuse_instances_default=reuse_instances_default,
+        convert_sets_default=convert_sets_default,
+    )
 
 
 @dataclass

--- a/serde/se.py
+++ b/serde/se.py
@@ -17,8 +17,8 @@ from uuid import UUID
 import jinja2
 
 from .compat import (is_bare_dict, is_bare_list, is_bare_tuple, is_dict, is_enum, is_list, is_opt, is_primitive,
-                     is_tuple, is_union, iter_types, type_args)
-from .core import HIDDEN_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen, logger
+                     is_tuple, is_union, iter_types, type_args, is_set, is_bare_set)
+from .core import (HIDDEN_NAME, SETTINGS, TO_DICT, TO_ITER, Field, Hidden, SerdeError, T, conv, fields, gen, logger)
 from .more_types import serialize as custom
 
 __all__: List = ['serialize', 'is_serializable', 'Serializer', 'to_tuple', 'to_dict']
@@ -361,6 +361,8 @@ class Renderer:
             return self.opt(arg)
         elif is_list(arg.type):
             return self.list(arg)
+        elif is_set(arg.type):
+            return self.set(arg)
         elif is_dict(arg.type):
             return self.dict(arg)
         elif is_tuple(arg.type):
@@ -415,6 +417,17 @@ class Renderer:
             earg = arg[0]
             earg.name = 'v'
             return f'[{self.render(earg)} for v in {arg.varname}]'
+
+    def set(self, arg: SeField) -> str:
+        """
+        Render rvalue for set.
+        """
+        if is_bare_set(arg.type):
+            return arg.varname
+        else:
+            earg = arg[0]
+            earg.name = 'v'
+            return f'set({self.render(earg)} for v in {arg.varname})'
 
     def tuple(self, arg: SeField) -> str:
         """

--- a/serde/se.py
+++ b/serde/se.py
@@ -38,7 +38,7 @@ class Serializer(metaclass=abc.ABCMeta):
         pass
 
 
-def serialize(_cls=None, rename_all: Optional[str] = None, reuse_instances_default: bool = True):
+def serialize(_cls=None, rename_all: Optional[str] = None, reuse_instances_default: bool = True, convert_sets_default: bool = False):
     """
     `serialize` decorator. A dataclass with this decorator can be serialized
     into an object in various data format such as JSON and MsgPack.
@@ -97,8 +97,11 @@ def serialize(_cls=None, rename_all: Optional[str] = None, reuse_instances_defau
         g['is_dataclass'] = is_dataclass
         g['__custom_serializer__'] = custom
         g['__serde_enum_value__'] = enum_value
-        cls = se_func(cls, TO_ITER, render_to_tuple(cls, reuse_instances_default, custom), g)
-        cls = se_func(cls, TO_DICT, render_to_dict(cls, rename_all, reuse_instances_default, custom), g)
+
+        to_tuple_code = render_to_tuple(cls, reuse_instances_default, convert_sets_default, custom)
+        cls = se_func(cls, TO_ITER, to_tuple_code, g)
+        to_dict_code = render_to_dict(cls, rename_all, reuse_instances_default, convert_sets_default, custom)
+        cls = se_func(cls, TO_DICT, to_dict_code, g)
         return cls
 
     if _cls is None:
@@ -125,15 +128,15 @@ def is_serializable(instance_or_class: Any) -> bool:
     return hasattr(instance_or_class, TO_ITER) or hasattr(instance_or_class, TO_DICT)
 
 
-def to_obj(o, named: bool, reuse_instances: bool):
-    thisfunc = functools.partial(to_obj, named=named, reuse_instances=reuse_instances)
+def to_obj(o, named: bool, reuse_instances: bool, convert_sets: bool):
+    thisfunc = functools.partial(to_obj, named=named, reuse_instances=reuse_instances, convert_sets=convert_sets)
     if o is None:
         return None
     if is_serializable(o):
         if named:
-            return getattr(o, TO_DICT)(reuse_instances=reuse_instances)
+            return getattr(o, TO_DICT)(reuse_instances=reuse_instances, convert_sets=convert_sets)
         else:
-            return getattr(o, TO_ITER)(reuse_instances=reuse_instances)
+            return getattr(o, TO_ITER)(reuse_instances=reuse_instances, convert_sets=convert_sets)
     elif is_dataclass(o):
         if named:
             return dataclasses.asdict(o)
@@ -155,10 +158,10 @@ def astuple(v):
     """
     Convert class with `serialize` to `tuple`.
     """
-    return to_tuple(v, reuse_instances=False)
+    return to_tuple(v, reuse_instances=False, convert_sets=False)
 
 
-def to_tuple(o, reuse_instances: bool = ...) -> Any:
+def to_tuple(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Any:
     """
     Convert object into tuple.
 
@@ -179,17 +182,17 @@ def to_tuple(o, reuse_instances: bool = ...) -> Any:
     >>> to_tuple((Foo(10), Foo(20)))
     ((10,), (20,))
     """
-    return to_obj(o, named=False, reuse_instances=reuse_instances)
+    return to_obj(o, named=False, reuse_instances=reuse_instances, convert_sets=convert_sets)
 
 
 def asdict(v):
     """
     Convert class with `serialize` to `dict`.
     """
-    return to_dict(v, reuse_instances=False)
+    return to_dict(v, reuse_instances=False, convert_sets=False)
 
 
-def to_dict(o, reuse_instances: bool = ...) -> Any:
+def to_dict(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Any:
     """
     Convert object into dictionary.
 
@@ -210,7 +213,7 @@ def to_dict(o, reuse_instances: bool = ...) -> Any:
     >>> to_dict((Foo(10), Foo(20)))
     ({'i': 10}, {'i': 20})
     """
-    return to_obj(o, named=True, reuse_instances=reuse_instances)
+    return to_obj(o, named=True, reuse_instances=reuse_instances, convert_sets=convert_sets)
 
 
 @dataclass
@@ -240,11 +243,16 @@ def to_arg(f: SeField) -> SeField:
     return f
 
 
-def render_to_tuple(cls: Type, reuse_instances_default: bool = True, custom: Custom = None) -> str:
+def render_to_tuple(cls: Type,
+                   reuse_instances_default: bool = True,
+                   convert_sets_default: bool = False,
+                   custom: Custom = None) -> str:
     template = """
-def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
+def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = {{convert_sets_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{reuse_instances_default}}
+  if convert_sets is Ellipsis:
+    convert_sets = {{convert_sets_default}}
 
   if not is_dataclass(obj):
     return copy.deepcopy(obj)
@@ -271,16 +279,22 @@ def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
     env.filters.update({'is_dataclass': is_dataclass})
     env.filters.update({'rvalue': renderer.render})
     env.filters.update({'arg': to_arg})
-    return env.get_template('iter').render(func=TO_ITER, cls=cls, reuse_instances_default=reuse_instances_default)
+    return env.get_template('iter').render(func=TO_ITER, cls=cls,
+                                           reuse_instances_default=reuse_instances_default,
+                                           convert_sets_default=convert_sets_default)
 
 
 def render_to_dict(
-    cls: Type, case: Optional[str] = None, reuse_instances_default: bool = True, custom: Custom = None
-) -> str:
+        cls: Type, case: Optional[str] = None,
+        reuse_instances_default: bool = True,
+        convert_sets_default: bool = False,
+        custom: Custom = None) -> str:
     template = """
-def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
+def {{func}}(obj, reuse_instances = {{reuse_instances_default}}, convert_sets = {{convert_sets_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{reuse_instances_default}}
+  if convert_sets is Ellipsis:
+    convert_sets = {{convert_sets_default}}
 
   if not is_dataclass(obj):
     return copy.deepcopy(obj)
@@ -314,7 +328,9 @@ def {{func}}(obj, reuse_instances = {{reuse_instances_default}}):
     env.filters.update({'rvalue': renderer.render})
     env.filters.update({'arg': to_arg})
     env.filters.update({'case': functools.partial(conv, case=case)})
-    return env.get_template('dict').render(func=TO_DICT, cls=cls, reuse_instances_default=reuse_instances_default)
+    return env.get_template('dict').render(func=TO_DICT, cls=cls,
+                                           reuse_instances_default=reuse_instances_default,
+                                           convert_sets_default=convert_sets_default)
 
 
 @dataclass
@@ -341,19 +357,19 @@ class Renderer:
         ... class Foo:
         ...    val: int
         >>> Renderer(TO_ITER).render(SeField(Foo, 'foo'))
-        'foo.__serde_to_iter__(reuse_instances=reuse_instances)'
+        'foo.__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets)'
 
         >>> Renderer(TO_ITER).render(SeField(List[Foo], 'foo'))
-        '[v.__serde_to_iter__(reuse_instances=reuse_instances) for v in foo]'
+        '[v.__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets) for v in foo]'
 
         >>> Renderer(TO_ITER).render(SeField(Dict[str, Foo], 'foo'))
-        '{k: v.__serde_to_iter__(reuse_instances=reuse_instances) for k, v in foo.items()}'
+        '{k: v.__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets) for k, v in foo.items()}'
 
         >>> Renderer(TO_ITER).render(SeField(Dict[Foo, Foo], 'foo'))
-        '{k.__serde_to_iter__(reuse_instances=reuse_instances): v.__serde_to_iter__(reuse_instances=reuse_instances) for k, v in foo.items()}'
+        '{k.__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets): v.__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets) for k, v in foo.items()}'
 
         >>> Renderer(TO_ITER).render(SeField(Tuple[str, Foo, int], 'foo'))
-        '(foo[0], foo[1].__serde_to_iter__(reuse_instances=reuse_instances), foo[2])'
+        '(foo[0], foo[1].__serde_to_iter__(reuse_instances=reuse_instances, convert_sets=convert_sets), foo[2])'
         """
         if is_dataclass(arg.type):
             return self.dataclass(arg)
@@ -397,7 +413,7 @@ class Renderer:
         """
         Render rvalue for dataclass.
         """
-        return f'{arg.varname}.{self.func}(reuse_instances=reuse_instances)'
+        return f'{arg.varname}.{self.func}(reuse_instances=reuse_instances, convert_sets=convert_sets)'
 
     def opt(self, arg: SeField) -> str:
         """
@@ -423,11 +439,11 @@ class Renderer:
         Render rvalue for set.
         """
         if is_bare_set(arg.type):
-            return arg.varname
+            return f'list({arg.varname}) if convert_sets else {arg.varname}'
         else:
             earg = arg[0]
             earg.name = 'v'
-            return f'set({self.render(earg)} for v in {arg.varname})'
+            return f'[{self.render(earg)} for v in {arg.varname}] if convert_sets else set({self.render(earg)} for v in {arg.varname})'
 
     def tuple(self, arg: SeField) -> str:
         """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Dict, List, Optional, Tuple, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import more_itertools
 import pytest

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 
 import more_itertools
 import pytest
@@ -61,6 +61,10 @@ types: List = [
     ([1, 2], List),
     ([1, 2], list),
     ([], List[int]),
+    ({1, 2}, Set[int]),
+    ({1, 2}, Set),
+    ({1, 2}, set),
+    (set(), Set[int]),
     ((1, 1), Tuple[int, int]),
     ((1, 1), Tuple),
     ({'a': 1}, Dict[str, int]),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,11 +1,11 @@
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, Set
 
 import pytest
 
 from serde import typecheck
-from serde.compat import is_dict, is_list, is_opt, is_tuple, is_union, iter_types, type_args, union_args
+from serde.compat import is_dict, is_list, is_opt, is_tuple, is_union, iter_types, type_args, union_args, is_set
 
 from .data import Bool, Float, Int, Pri, PriOpt, Str
 
@@ -13,6 +13,8 @@ from .data import Bool, Float, Int, Pri, PriOpt, Str
 def test_types():
     assert is_list(List[int])
     assert is_list(List)
+    assert is_set(Set[int])
+    assert is_set(Set)
     assert is_tuple(Tuple[int, int, int])
     assert is_tuple(Tuple)
     assert is_dict(Dict[str, int])
@@ -25,13 +27,16 @@ def test_types():
     assert not is_opt(Union[Optional[int], Optional[str]])
     assert is_union(Union[Optional[int], Optional[str]])
 
+    assert is_list(list)
+    assert is_set(set)
+    assert is_tuple(tuple)
+    assert is_dict(dict)
+
     if sys.version_info[:3] >= (3, 9, 0):
         assert is_list(list[int])
-        assert is_list(list)
+        assert is_set(set[int])
         assert is_tuple(tuple[int, int, int])
-        assert is_tuple(tuple)
         assert is_dict(dict[str, int])
-        assert is_dict(dict)
 
 
 def test_iter_types():

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,11 +1,11 @@
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union, Set
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import pytest
 
 from serde import typecheck
-from serde.compat import is_dict, is_list, is_opt, is_tuple, is_union, iter_types, type_args, union_args, is_set
+from serde.compat import is_dict, is_list, is_opt, is_set, is_tuple, is_union, iter_types, type_args, union_args
 
 from .data import Bool, Float, Int, Pri, PriOpt, Str
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -104,6 +104,11 @@ def test_typecheck():
     with pytest.raises(ValueError):
         typecheck(List[Pri], [Pri(i=10.0, s='foo', f=100.0, b=True)])
 
+    # Set
+    typecheck(Set[int], {10})
+    with pytest.raises(ValueError):
+        typecheck(Set[int], {10.0})
+
     # Tuple
     typecheck(Tuple[int, str, float, bool], (10, 'foo', 100.0, True))
     with pytest.raises(ValueError):

--- a/tests/test_se.py
+++ b/tests/test_se.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Set
 
-from serde import asdict, astuple, to_dict, to_tuple, serialize
+from serde import asdict, astuple, serialize, to_dict, to_tuple
 from serde.json import to_json
 from serde.msgpack import to_msgpack
 
@@ -94,7 +94,7 @@ def test_convert_sets_option():
     class A:
         v: Set[str]
 
-    a = A({"a","b"})
+    a = A({"a", "b"})
 
     a_json = to_json(a)
     # sets are unordered so the list order is not stable
@@ -106,6 +106,6 @@ def test_convert_sets_option():
 
     a_dict = to_dict(a, convert_sets=True)
     # sets are unordered so the list order is not stable
-    assert a_dict == {"v": ["a","b"]} or a_dict == {"v": ["b","a"]}
+    assert a_dict == {"v": ["a", "b"]} or a_dict == {"v": ["b", "a"]}
 
-    assert {"v": {"a","b"}} == to_dict(a, convert_sets=False)
+    assert {"v": {"a", "b"}} == to_dict(a, convert_sets=False)

--- a/tests/test_se.py
+++ b/tests/test_se.py
@@ -1,4 +1,9 @@
-from serde import asdict, astuple, to_dict, to_tuple
+from dataclasses import dataclass
+from typing import Set
+
+from serde import asdict, astuple, to_dict, to_tuple, serialize
+from serde.json import to_json
+from serde.msgpack import to_msgpack
 
 from . import data
 from .data import (Bool, Float, Int, NestedInt, NestedPri, NestedPriDict, NestedPriList, NestedPriTuple, Pri, PriDict,
@@ -81,3 +86,26 @@ def test_se_func_iter():
 
     # Optional
     assert (10, '10', 10.0, False) == PriOpt(10, "10", 10.0, False).__serde_to_iter__()
+
+
+def test_convert_sets_option():
+    @serialize
+    @dataclass
+    class A:
+        v: Set[str]
+
+    a = A({"a","b"})
+
+    a_json = to_json(a)
+    # sets are unordered so the list order is not stable
+    assert a_json == '{"v": ["a", "b"]}' or a_json == '{"v": ["b", "a"]}'
+
+    a_msgpack = to_msgpack(a)
+    # sets are unordered so the list order is not stable
+    assert a_msgpack == b'\x81\xa1v\x92\xa1a\xa1b' or a_msgpack == b'\x81\xa1v\x92\xa1b\xa1a'
+
+    a_dict = to_dict(a, convert_sets=True)
+    # sets are unordered so the list order is not stable
+    assert a_dict == {"v": ["a","b"]} or a_dict == {"v": ["b","a"]}
+
+    assert {"v": {"a","b"}} == to_dict(a, convert_sets=False)


### PR DESCRIPTION
While I thought about https://github.com/yukinarit/pyserde/pull/87 I accidentally started to implement support for sets 😄 
But this time I managed to keep it separate.

I had to add another `to_dict` option named  `convert_sets`, which converts sets to lists during serializing. This is required for `to_json` & `to_msgpack` since they do not support sets.

A small annoyance of the conversion is that the order of items in the lists is not deterministic because sets are unordered.

This also closes #58 I just removed the pytest.ini because the only option in it does not exist anymore.
Also see https://docs.pytest.org/en/stable/reference.html#ini-options-ref

If the tests pass this is ready to be merged.