### PR TITLE
build: Don't install dataclasses for python>3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import pathlib
 import re
-import sys
 from codecs import open
 from setuptools import setup, find_packages
 
@@ -17,6 +16,7 @@ setup_requires = [
 ]
 
 requires = [
+    'dataclasses;python_version==\'3.6\'',
     'stringcase',
     'typing_inspect>=0.4.0',
     'jinja2',
@@ -24,10 +24,6 @@ requires = [
 msgpack_requires = ['msgpack']
 toml_requires = ['toml']
 yaml_requires = ['pyyaml']
-
-# Installs dataclasses from PyPI for python < 3.7
-if sys.version_info < (3, 7):
-    requires.append('dataclasses')
 
 tests_require = [
     'coverage',


### PR DESCRIPTION
Specifying `"dataclasses;python_version=='3.6'"` fixed the issue.

```
❰yukinari❙~/repos/test❱✔≻ pip install -e ../pyserde
Obtaining file:///Users/yukinari/repos/pyserde
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... done
Requirement already satisfied: stringcase in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from pyserde==0.2.2) (1.2.0)
Requirement already satisfied: typing-inspect>=0.4.0 in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from pyserde==0.2.2) (0.6.0)
Requirement already satisfied: jinja2 in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from pyserde==0.2.2) (2.11.3)
Requirement already satisfied: mypy-extensions>=0.3.0 in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from typing-inspect>=0.4.0->pyserde==0.2.2) (0.4.3)
Requirement already satisfied: typing-extensions>=3.7.4 in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from typing-inspect>=0.4.0->pyserde==0.2.2) (3.7.4.3)
Requirement already satisfied: MarkupSafe>=0.23 in /Users/yukinari/.pyenv/versions/3.8.3/envs/test/lib/python3.8/site-packages (from jinja2->pyserde==0.2.2) (1.1.1)
Installing collected packages: pyserde
  Running setup.py develop for pyserde
Successfully installed pyserde
WARNING: You are using pip version 20.1.1; however, version 21.0.1 is available.
You should consider upgrading via the '/Users/yukinari/.pyenv/versions/3.8.3/envs/test/bin/python -m pip install --upgrade pip' command.
```

```
❰yukinari❙~/repos/test❱✔≻ pip list
Package           Version Location
----------------- ------- -----------------------------
Jinja2            2.11.3
MarkupSafe        1.1.1
mypy-extensions   0.4.3
pip               20.1.1
pyserde           0.2.2   /Users/yukinari/repos/pyserde
setuptools        46.4.0
stringcase        1.2.0
typing-extensions 3.7.4.3
typing-inspect    0.6.0
wheel             0.34.2
```