### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import pathlib
 import re
-import sys
 from codecs import open
 from setuptools import setup, find_packages
 
@@ -17,6 +16,7 @@ setup_requires = [
 ]
 
 requires = [
+    'dataclasses;python_version==\'3.6\'',
     'stringcase',
     'typing_inspect>=0.4.0',
     'jinja2',
@@ -24,10 +24,6 @@ requires = [
 msgpack_requires = ['msgpack']
 toml_requires = ['toml']
 yaml_requires = ['pyyaml']
-
-# Installs dataclasses from PyPI for python < 3.7
-if sys.version_info < (3, 7):
-    requires.append('dataclasses')
 
 tests_require = [
     'coverage',

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     author_email='yukinarit84@gmail.com',
     url='https://github.com/yukinarit/pyserde',
     packages=find_packages(exclude=['test_serde', 'bench']),
+    package_data={'serde': ['py.typed']},
     python_requires=">=3.6",
     setup_requires=setup_requires,
     install_requires=requires,


### PR DESCRIPTION
This file is needed to let type checker use pyserde's inline type annotation.

See PEP561 for more information.
https://www.python.org/dev/peps/pep-0561/
