### PR TITLE
Reject unformatted code by CI (fix #88)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,35 @@ jobs:
         pytest tests --doctest-modules serde -v
         cd examples && python runner.py
 
+  check_formatting:
+    name: Check formatting
+    needs: test
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Restore pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ubuntu-20.04-${{ env.pythonLocation }}-${{ hashFiles('**/.pre-commit-config.yaml', '**/pyproject.toml') }}
+    - name: Install dependencies
+      run: |
+        pip install pre-commit
+        pre-commit install
+    - name: Check formatting
+      run: pre-commit run -a
+    - name: Comment PR
+      if: ${{ failure() && github.event_name == 'pull_request' }}
+      uses: thollander/actions-comment-pull-request@master
+      with:
+        message: 'Please consider formatting your code according to the standards described here: https://github.com/yukinarit/pyserde/blob/master/CONTRIBUTING.md'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   check_coverage:
     name: Check coverage
     needs: test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+exclude: '.git|.tox'
+files: 'serde/|tests/|examples/|bench/bench.py'
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+      - id: isort

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# How to contribute to Pyserde
+
+Thank you for considering contributing to Pyserde!
+
+## Reporting issues
+- Describe what you expected to happen.
+- If possible, include a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) to help us identify the issue. This also helps check that the issue is not with your own code.
+- Describe what actually happened. Include the full traceback if there was an exception.
+- List your Python and Pyserde versions. If possible, check if this issue is already fixed in the repository.
+
+## Submitting patches
+- Pyserde uses Black and isort to autoformat your code. This should be done for you as a git pre-commit hook, which gets installed when you run `make setup` but you can do it manually via `make fmt`.
+- Include tests if your patch is supposed to solve a bug, and explain clearly under which circumstances the bug happens. Make sure the test fails without your patch.
+- Use [Conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification for your commit messages.
+- Include a string like “Fixes #123” in your commit message (where 123 is the issue you fixed). See [Closing issues using keywords](https://help.github.com/articles/creating-a-pull-request/).
+
+### First time setup
+- Download and install the latest version of [git](https://git-scm.com/downloads).
+- Configure git with your [username](https://help.github.com/articles/setting-your-username-in-git/) and [email](https://help.github.com/articles/setting-your-email-in-git/):
+  ```bash
+  git config --global user.name 'your name'
+  git config --global user.email 'your email'
+  ```
+- Make sure you have a [GitHub account](https://github.com/join).
+- Fork Pyserde to your GitHub account by clicking the [Fork](https://github.com/yukinarit/pyserde/fork) button.
+- [Clone](https://help.github.com/en/articles/fork-a-repo#step-2-create-a-local-clone-of-your-fork) your GitHub fork locally:
+  ```bash
+  git clone https://github.com/{your-github-username}/pyserde
+  cd pyserde
+  ```
+- Add the main repository as a remote to update later:
+  ```bash
+  git remote add upstream https://github.com/yukinarit/pyserde
+  git fetch upstream
+  ```
+- Install pipenv:
+  ```bash
+  pip install pipenv
+  ```
+- Run setup script:
+  ```bash
+  make setup
+  ```
+
+### Start coding
+- Create a branch to identify the issue you would like to work on:
+  ```bash
+  git checkout -b your-branch-name origin/master
+  ```
+- Using your favorite editor, make your changes, committing as you go.
+- Include tests that cover any code changes you make. Make sure the test fails without your patch. Run the tests via `make test`.
+- Push your commits to GitHub and [create a pull request](https://help.github.com/en/articles/creating-a-pull-request) by using:
+  ```bash
+  git push --set-upstream origin your-branch-name
+  ```

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ all: setup pep8 mypy docs test examples
 setup:
 	$(PIPENV) install --dev --skip-lock
 	$(PIPENV) run pip list
+	$(PIPENV) run pre-commit install
 	pushd examples && $(PIPENV) install --dev && popd
 
 setup-bench:
@@ -34,8 +35,7 @@ mypy:
 	$(PIPENV) run mypy serde
 
 fmt:
-	$(PIPENV) run black serde tests examples bench/bench.py
-	$(PIPENV) run isort -rc --atomic serde tests bench/bench.py
+	$(PIPENV) run pre-commit run -a
 
 docs:
 	mkdir -p docs

--- a/Pipfile
+++ b/Pipfile
@@ -21,9 +21,8 @@ coverage = "==4.5.4"
 pdoc3 = "~=0.9"
 mypy = {version = "==0.782",markers = "platform_python_implementation!='PyPy'"}
 twine = "*"
-black = "==19.3b0"
-isort = "==4.3.21"
 more-itertools = "~=8.6.0"
+pre-commit = "==v2.10.1"
 
 [pipenv]
 allow_prereleases = true

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -10,7 +10,6 @@ from platform import python_implementation
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import click
-
 import data
 import dataclasses_class as dc
 import pyserde_class as ps  # noqa: F401
@@ -19,14 +18,14 @@ from runner import Size
 
 try:
     if python_implementation() != 'PyPy':
-        import dacite_class as da  # noqa: F401
-        import mashumaro_class as mc  # noqa: F401
-        import marshmallow_class as ms  # noqa: F401
         import attrs_class as at  # noqa: F401
         import cattrs_class as ca  # noqa: F401
-        import seaborn as sns
+        import dacite_class as da  # noqa: F401
+        import marshmallow_class as ms  # noqa: F401
+        import mashumaro_class as mc  # noqa: F401
         import matplotlib.pyplot as plt
         import numpy as np
+        import seaborn as sns
 except ImportError:
     pass
 

--- a/examples/collection.py
+++ b/examples/collection.py
@@ -1,8 +1,9 @@
 import sys
 from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
 from serde import deserialize, serialize
 from serde.json import from_json, to_json
-from typing import List, Tuple, Dict
 
 PY39 = sys.version_info[:3] >= (3, 9, 0)
 

--- a/examples/default.py
+++ b/examples/default.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
+from typing import Dict
+
 from serde import deserialize, serialize
 from serde.json import from_json, to_json
-from typing import Dict
 
 
 @deserialize

--- a/examples/enum34.py
+++ b/examples/enum34.py
@@ -1,9 +1,10 @@
 import enum
 from dataclasses import dataclass
-from serde import serialize, deserialize
-from serde.json import to_json, from_json
 
 import imported
+
+from serde import deserialize, serialize
+from serde.json import from_json, to_json
 
 
 class Nested(enum.Enum):

--- a/examples/env.py
+++ b/examples/env.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+
 from envclasses import envclass, load_env
+
 from serde import deserialize
 from serde.yaml import from_yaml
 

--- a/examples/jsonfile.py
+++ b/examples/jsonfile.py
@@ -7,10 +7,11 @@ Usage:
     $ pipenv install
     $ pipenv run jsonfile.py
 """
+from dataclasses import dataclass
+from typing import List, Optional
+
 import requests
 
-from typing import List, Optional
-from dataclasses import dataclass
 from serde import deserialize
 from serde.json import from_json
 

--- a/examples/rename.py
+++ b/examples/rename.py
@@ -7,6 +7,7 @@ Usage:
     $ pipenv run rename.py
 """
 from dataclasses import dataclass, field
+
 from serde import serialize
 from serde.json import to_json
 

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -1,15 +1,15 @@
 import sys
 
-import simple
 import collection
 import default
 import env
 import jsonfile
 import rename
+import simple
 import skip
 import tomlfile
-import yamlfile
 import union
+import yamlfile
 
 
 def run_all():

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from serde import deserialize, serialize
 from serde.json import from_json, to_json
 

--- a/examples/skip.py
+++ b/examples/skip.py
@@ -8,9 +8,10 @@ Usage:
     $ pipenv run skip.py
 """
 
-from typing import List, Dict
 from dataclasses import dataclass, field
-from serde import serialize, deserialize
+from typing import Dict, List
+
+from serde import deserialize, serialize
 from serde.json import to_json
 
 

--- a/examples/tomlfile.py
+++ b/examples/tomlfile.py
@@ -7,8 +7,9 @@ Usage:
     $ pipenv install
     $ pipenv run tomlfile.py
 """
-from typing import List, Dict, Optional, Union
 from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
 from serde import deserialize
 from serde.toml import from_toml
 

--- a/examples/union.py
+++ b/examples/union.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
+from typing import Dict, List, Union
+
 from serde import deserialize, serialize
 from serde.json import from_json, to_json
-from typing import Union, List, Dict
 
 
 @deserialize

--- a/examples/webapi/README.md
+++ b/examples/webapi/README.md
@@ -20,4 +20,3 @@ pipenv run python app.py
     $ curl -X POST http://localhost:5000/todos -d '{"id": 1, "title": "Play games", "description": "Play 聖剣伝説3", "done": false}'
     A new ToDo ToDo(id=1, title='Play games', description='Play 聖剣伝説3', done=False) successfully created.⏎
     ```
-

--- a/examples/webapi/app.py
+++ b/examples/webapi/app.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
-from flask import Flask, request, Response
-from serde import serialize, deserialize
-from serde.json import to_json, from_json
+
+from flask import Flask, Response, request
+
+from serde import deserialize, serialize
+from serde.json import from_json, to_json
 
 
 @deserialize

--- a/examples/yamlfile.py
+++ b/examples/yamlfile.py
@@ -7,8 +7,9 @@ Usage:
     $ pipenv install
     $ pipenv run yamlfile.py
 """
-from typing import List, Dict, Optional, Union
 from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
 from serde import deserialize
 from serde.yaml import from_yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,12 @@
 line-length = 120
 target-version = ['py36', 'py37', 'py38']
 skip-string-normalization = true
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120
+atomic = true

--- a/serde/core.py
+++ b/serde/core.py
@@ -9,8 +9,20 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Type, Union
 
 import stringcase
 
-from .compat import (is_bare_dict, is_bare_list, is_bare_set, is_bare_tuple, is_dict, is_list, is_opt, is_set, is_tuple,
-                     is_union, type_args, typename)
+from .compat import (
+    is_bare_dict,
+    is_bare_list,
+    is_bare_set,
+    is_bare_tuple,
+    is_dict,
+    is_list,
+    is_opt,
+    is_set,
+    is_tuple,
+    is_union,
+    type_args,
+    typename,
+)
 
 __all__: List = []
 
@@ -75,7 +87,7 @@ def gen(code: str, globals: Dict = None, locals: Dict = None) -> str:
     Customized `exec` function.
     """
     try:
-        from black import format_str, FileMode
+        from black import FileMode, format_str
 
         code = format_str(code, mode=FileMode(line_length=100))
     except Exception:

--- a/serde/de.py
+++ b/serde/de.py
@@ -24,11 +24,42 @@ from uuid import UUID
 
 import jinja2
 
-from .compat import (has_default, has_default_factory, is_bare_dict, is_bare_list, is_bare_set, is_bare_tuple, is_dict,
-                     is_enum, is_list, is_none, is_opt, is_primitive, is_set, is_tuple, is_union, iter_types,
-                     iter_unions, type_args, typename)
-from .core import (FROM_DICT, FROM_ITER, SERDE_SCOPE, UNION_DE_PREFIX, Field, SerdeError, SerdeScope, add_func, conv,
-                   fields, logger, raise_unsupported_type, union_func_name)
+from .compat import (
+    has_default,
+    has_default_factory,
+    is_bare_dict,
+    is_bare_list,
+    is_bare_set,
+    is_bare_tuple,
+    is_dict,
+    is_enum,
+    is_list,
+    is_none,
+    is_opt,
+    is_primitive,
+    is_set,
+    is_tuple,
+    is_union,
+    iter_types,
+    iter_unions,
+    type_args,
+    typename,
+)
+from .core import (
+    FROM_DICT,
+    FROM_ITER,
+    SERDE_SCOPE,
+    UNION_DE_PREFIX,
+    Field,
+    SerdeError,
+    SerdeScope,
+    add_func,
+    conv,
+    fields,
+    logger,
+    raise_unsupported_type,
+    union_func_name,
+)
 from .py36_datetime_compat import py36_date_fromisoformat, py36_datetime_fromisoformat
 
 __all__: List = ['deserialize', 'is_deserializable', 'Deserializer', 'from_dict', 'from_tuple']
@@ -545,7 +576,7 @@ def render_from_iter(cls: Type) -> str:
 def {{func}}(data, reuse_instances = {{serde_scope.reuse_instances_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{serde_scope.reuse_instances_default}}
-    
+
   {# List up all classes used by this class. -#}
   {% for name in serde_scope.types.keys() -%}
   {{name}} = serde_scope.types['{{name}}']
@@ -573,7 +604,7 @@ def render_from_dict(cls: Type, rename_all: Optional[str] = None) -> str:
 def {{func}}(data, reuse_instances = {{serde_scope.reuse_instances_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{serde_scope.reuse_instances_default}}
-    
+
   {# List up all classes used by this class. #}
   {% for name in serde_scope.types.keys() %}
   {{name}} = serde_scope.types['{{name}}']
@@ -605,7 +636,7 @@ def {{func}}(data, reuse_instances):
 
   # create fake dict so we can reuse the normal render function
   fake_dict = {"fake_key":data}
-  
+
   error = "Exhausted all types"
   {% for t in union_args %}
   {% if t | is_primitive or t | is_none %}

--- a/serde/se.py
+++ b/serde/se.py
@@ -16,10 +16,42 @@ from uuid import UUID
 
 import jinja2
 
-from .compat import (T, is_bare_dict, is_bare_list, is_bare_set, is_bare_tuple, is_dict, is_enum, is_list, is_none,
-                     is_opt, is_primitive, is_set, is_tuple, is_union, iter_types, iter_unions, type_args, typename)
-from .core import (SERDE_SCOPE, TO_DICT, TO_ITER, UNION_SE_PREFIX, Field, SerdeError, SerdeScope, add_func, conv,
-                   fields, is_instance, logger, raise_unsupported_type, union_func_name)
+from .compat import (
+    T,
+    is_bare_dict,
+    is_bare_list,
+    is_bare_set,
+    is_bare_tuple,
+    is_dict,
+    is_enum,
+    is_list,
+    is_none,
+    is_opt,
+    is_primitive,
+    is_set,
+    is_tuple,
+    is_union,
+    iter_types,
+    iter_unions,
+    type_args,
+    typename,
+)
+from .core import (
+    SERDE_SCOPE,
+    TO_DICT,
+    TO_ITER,
+    UNION_SE_PREFIX,
+    Field,
+    SerdeError,
+    SerdeScope,
+    add_func,
+    conv,
+    fields,
+    is_instance,
+    logger,
+    raise_unsupported_type,
+    union_func_name,
+)
 
 __all__: List = ['serialize', 'is_serializable', 'Serializer', 'to_tuple', 'to_dict']
 
@@ -339,9 +371,9 @@ def {{func}}(obj, reuse_instances):
   {% for name in serde_scope.types.keys() %}
   {{name}} = serde_scope.types['{{name}}']
   {% endfor %}
-  
+
   union_args = serde_scope.union_se_args['{{func}}']
-  
+
   {% for t in union_args %}
   if is_instance(obj, union_args[{{loop.index0}}]):
     return {{t|arg|rvalue()}}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -268,8 +268,9 @@ def test_dict(se, de, opt):
 @pytest.mark.parametrize('opt', opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize('se,de', all_formats)
 def test_enum(se, de, opt):
-    from .data import E, IE
     from serde.compat import is_enum
+
+    from .data import IE, E
 
     class Inner(enum.IntEnum):
         V0 = enum.auto()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -2,8 +2,18 @@ import sys
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from serde.compat import (is_dict, is_list, is_opt, is_set, is_tuple, is_union, iter_types, iter_unions, type_args,
-                          union_args)
+from serde.compat import (
+    is_dict,
+    is_list,
+    is_opt,
+    is_set,
+    is_tuple,
+    is_union,
+    iter_types,
+    iter_unions,
+    type_args,
+    union_args,
+)
 from serde.core import is_instance
 
 from .data import Bool, Float, Int, Pri, PriOpt, Str

--- a/tests/test_se.py
+++ b/tests/test_se.py
@@ -6,8 +6,22 @@ from serde.json import to_json
 from serde.msgpack import to_msgpack
 
 from . import data
-from .data import (Bool, Float, Int, NestedInt, NestedPri, NestedPriDict, NestedPriList, NestedPriTuple, Pri, PriDict,
-                   PriList, PriOpt, PriTuple, Str)
+from .data import (
+    Bool,
+    Float,
+    Int,
+    NestedInt,
+    NestedPri,
+    NestedPriDict,
+    NestedPriList,
+    NestedPriTuple,
+    Pri,
+    PriDict,
+    PriList,
+    PriOpt,
+    PriTuple,
+    Str,
+)
 
 
 def test_asdict():


### PR DESCRIPTION
So, here’s my proposal. We will use pre-commit ([pre-commit.com](https://pre-commit.com/)) to automate all formatting stuff both on the dev machine and in CI cycle. 

Pre-commit is a framework which runs a set of actions defined in .pre-commit-config.yaml after git commit/push etc. Here we want it to run black and isort. 

I’ve:
- made a pre-commit config to run black, isort and some basic text-formatting stuff
- put both black and isort settings into pyproject.toml 
- included pre-commit as a dependency in Pipfile and removed black and isort from the list (as pre-commit will manage setup of the tools)
- modified Makefiles’ `setup` command slightly to let pre-commit setup git hooks 
- modified the `fmt` command to use pre-commit
- added code style check to test workflow in CI 
- formatted a few previously unformatted files in the repo


Now after cloning the repo and running `make setup` a contributor:
- will be able to manually format the code via `make fmt` as usual
- will not be able to commit unformatted code because pre-commit will locally deny it, format the files committed and force a contributor to push properly formatted ones  


When PR is made:
- CI will double check the code formatting
- a comment will be auto-posted if PR contents are poorly formatted ([sample](https://github.com/alexmisk/pyserde/pull/7))


Please give it a shot and tell me what you think.

If the whole idea fits I will write a CONTRIBUTION.md and describe the setup to future contributors.