### PR TITLE
Fix case conversion for optional

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -234,6 +234,14 @@ class Field:
         """
         return f'{field.name}_{name}'
 
+    @property
+    def conv_name(self) -> str:
+        """
+        Get an actual field name which `rename` and `rename_all` conversions
+        are made. Use `name` property to get a field name before conversion.
+        """
+        return conv(self, self.case)
+
 
 def fields(FieldCls: Type, cls: Type) -> Iterator[Field]:
     return iter(FieldCls.from_dataclass(f) for f in dataclasses.fields(cls))
@@ -245,12 +253,10 @@ def conv(f: Field, case: Optional[str] = None) -> str:
     """
     name = f.name
     if case:
-        casef = getattr(stringcase, case or '', None)
+        casef = getattr(stringcase, case, None)
         if not casef:
-            raise SerdeError(
-                (f"Unkown case type: {f.case}." f"Pass the name of case supported by 'stringcase' package.")
-            )
-        name = casef(f.name)
+            raise SerdeError(f"Unkown case type: {f.case}. Pass the name of case supported by 'stringcase' package.")
+        name = casef(name)
     if f.rename:
         name = f.rename
     if name is None:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -277,3 +277,14 @@ def test_union_in_other_type():
     a_int = A({"key": 1})
     assert a_int == from_dict(A, to_dict(a_int, reuse_instances=False), reuse_instances=False)
     assert a_int == from_dict(A, to_dict(a_int, reuse_instances=True), reuse_instances=True)
+
+
+def test_union_rename_all():
+    @deserialize(rename_all='pascalcase')
+    @serialize(rename_all='pascalcase')
+    @dataclass
+    class Foo:
+        bar_baz: Union[int, str]
+
+    assert to_dict(Foo(10)) == {'BarBaz': 10}
+    assert from_dict(Foo, {'BarBaz': 'foo'}) == Foo('foo')


### PR DESCRIPTION
Close #100 

* Add a new property `conv_name`
* Use `conv_name` whereever the name after conversion is needed
