### PR TITLE
CI: pin runner OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
  build_docs:
    name: Build docs and deploy to gh-pages
-   runs-on: ubuntu-latest
+   runs-on: ubuntu-20.04
    steps:
      - name: Checkout
        uses: actions/checkout@v2.3.1
@@ -23,7 +23,7 @@ jobs:
        uses: actions/cache@v2
        with:
          path: ${{ env.pythonLocation }}
-         key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
+         key: ubuntu-20.04-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
      - name: Install dependencies
        run: |
          pip install pipenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Restore pip cache
       # Caching on Windows is turned off due to inconsistent behaviour
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-2019'
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
@@ -39,7 +39,7 @@ jobs:
   check_coverage:
     name: Check coverage
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
+        key: ubuntu-20.04-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
     - name: Install dependencies
       run: |
         pip install pipenv
@@ -64,7 +64,7 @@ jobs:
   run_benchmark:
     name: Run benchmark
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ubuntu-latest-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
+        key: ubuntu-20.04-${{ env.pythonLocation }}-${{ hashFiles('**/Pipfile') }}
     - name: Install dependencies
       run: |
         pip install pipenv


### PR DESCRIPTION
Well, it's almost always good to pin your dependencies, even CI runner OS versions :-) 

Recent migration of GitHub runners from Ubuntu 18.04 to 20.04 resulted in the situation in which runner with the newer Ubuntu version was restoring cache from the older one because they have the same cache key ("ubuntu-latest-..."). 

I pinned all OS versions in the pipeline to prevent this in future.