### PR TITLE
feat: Improve error description for union type

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -646,21 +646,21 @@ def {{func}}(data, reuse_instances):
   # create fake dict so we can reuse the normal render function
   fake_dict = {"fake_key":data}
 
-  error = "Exhausted all types"
+  errors = []
   {% for t in union_args %}
   {% if t | is_primitive or t | is_none %}
   if isinstance(data, {{t.__name__}}):
     return {{t|arg|rvalue}}
   else:
-    error = "input is not of type {{t.__name__}}"
+    errors.append("input is not of type {{t.__name__}}")
   {% else %}
   try:
     return {{t|arg|rvalue}}
   except Exception as e:
-    error = str(e)
+    errors.append(f' Failed to deserialize into {{t.__name__}}: {e}')
   {% endif %}
   {% endfor %}
-  raise SerdeError("Can not deserialize " + repr(data) + " of type " + typename(type(data)) + " into {{union_name}}. Reason: " + error)
+  raise SerdeError("Can not deserialize " + repr(data) + " of type " + typename(type(data)) + " into {{union_name}}.\\nReasons:\\n" + "\\n".join(errors))
     """
     union_name = f"Union[{', '.join([typename(a) for a in union_args])}]"
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -211,24 +211,26 @@ def test_union_exception_if_nothing_matches():
 
     with pytest.raises(SerdeError) as ex1:
         from_dict(A, {"v": "not-ip-or-uuid"})
-    assert (
-        str(ex1.value)
-        == "Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID]. Reason: badly formed hexadecimal UUID string"
+    assert str(ex1.value) == (
+        "Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID].\n"
+        "Reasons:\n"
+        " Failed to deserialize into IPv4Address: Expected 4 octets in 'not-ip-or-uuid'\n"
+        " Failed to deserialize into UUID: badly formed hexadecimal UUID string"
     )
 
     with pytest.raises(SerdeError) as ex2:
         from_dict(A, {"v": "not-ip-or-uuid"}, reuse_instances=True)
-    assert (
-        str(ex2.value)
-        == "Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID]. Reason: badly formed hexadecimal UUID string"
+    assert str(ex2.value) == (
+        "Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID].\n"
+        "Reasons:\n"
+        " Failed to deserialize into IPv4Address: Expected 4 octets in 'not-ip-or-uuid'\n"
+        " Failed to deserialize into UUID: badly formed hexadecimal UUID string"
     )
 
     with pytest.raises(SerdeError) as ex3:
         from_dict(A, {"v": None})
     # omit reason because it is not the same for all python versions & operating systems
-    assert str(ex3.value).startswith(
-        "Can not deserialize None of type NoneType into Union[IPv4Address, UUID]. Reason: "
-    )
+    assert str(ex3.value).startswith("Can not deserialize None of type NoneType into Union[IPv4Address, UUID].")
 
     with pytest.raises(SerdeError) as ex4:
         to_dict(A("not-ip-or-uuid"))


### PR DESCRIPTION
It's convenient if you can see what error each type in union received during deserialization.

Given this class,

```python
@deserialize
@serialize
@dataclass
class A:
    v: Union[IPv4Address, UUID]
```

Previously, this kind of error description are returned.

```
Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID]. Reason: badly formed hexadecimal UUID string
```

However, it's impossible to know why the type IPv4Address failed.

With this change, you can receive the following description instead.

```
Can not deserialize 'not-ip-or-uuid' of type str into Union[IPv4Address, UUID]
Reason:
Exhausted all types
 Failed to deserialize into IPv4Address: Expected 4 octets in 'not-ip-or-uuid
 Failed to deserialize into UUID: badly formed hexadecimal UUID string
```