### PR TITLE
refactor: Remove self class from scope

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -122,6 +122,9 @@ def deserialize(
 
         # Collect types used in the generated code.
         for typ in iter_types(cls):
+            if typ is cls:
+                continue
+
             if is_dataclass(typ) or is_enum(typ) or not is_primitive(typ):
                 scope.types[typ.__name__] = typ
 

--- a/serde/se.py
+++ b/serde/se.py
@@ -133,6 +133,9 @@ def serialize(
 
         # Collect types used in the generated code.
         for typ in iter_types(cls):
+            if typ is cls:
+                continue
+
             if is_dataclass(typ) or is_enum(typ) or not is_primitive(typ):
                 scope.types[typ.__name__] = typ
 


### PR DESCRIPTION
This will remove "Foo = serde_scope.types["Foo"]" from
the function generated for Foo.

```
def from_dict(data, reuse_instances=True):
    if reuse_instances is Ellipsis:
        reuse_instances = True

    Foo = serde_scope.types["Foo"]
    ...
```