### PR TITLE
Some bugfixes

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -159,6 +159,8 @@ def iter_unions(cls: Type) -> Iterator[Type]:
     """
     if is_union(cls):
         yield cls
+        for arg in type_args(cls):
+            yield from iter_unions(arg)
     if is_dataclass(cls):
         for f in fields(cls):
             yield from iter_unions(f.type)

--- a/serde/de.py
+++ b/serde/de.py
@@ -503,11 +503,11 @@ class Renderer:
         ... @dataclass
         ... class Foo: pass
         >>> Renderer('foo').render(DeField(Tuple[str, int, List[int], Foo], 'd', datavar='data'))
-        '(data["d"][0], data["d"][1], [v for v in data["d"][2]], Foo.__serde__.funcs[\\'foo\\'](data["d"][3], reuse_instances=reuse_instances))'
+        '(data["d"][0], data["d"][1], [v for v in data["d"][2]], Foo.__serde__.funcs[\\'foo\\'](data["d"][3], reuse_instances=reuse_instances),)'
 
         >>> field = DeField(Tuple[str, int, List[int], Foo], 'd', datavar='data', index=0, iterbased=True)
         >>> Renderer('foo').render(field)
-        "(data[0][0], data[0][1], [v for v in data[0][2]], Foo.__serde__.funcs['foo'](data[0][3], reuse_instances=reuse_instances))"
+        "(data[0][0], data[0][1], [v for v in data[0][2]], Foo.__serde__.funcs['foo'](data[0][3], reuse_instances=reuse_instances),)"
         """
         if is_bare_tuple(arg.type):
             return f'tuple({arg.data})'
@@ -516,7 +516,7 @@ class Renderer:
             for i, typ in enumerate(type_args(arg.type)):
                 inner = arg[i]
                 values.append(self.render(inner))
-            return f'({", ".join(values)})'
+            return f'({", ".join(values)},)'  # trailing , is required for single element tuples
 
     def dict(self, arg: DeField) -> str:
         """

--- a/serde/se.py
+++ b/serde/se.py
@@ -432,7 +432,7 @@ class Renderer:
         "{k.__serde__.funcs['to_iter'](k, reuse_instances=reuse_instances, convert_sets=convert_sets): v.__serde__.funcs['to_iter'](v, reuse_instances=reuse_instances, convert_sets=convert_sets) for k, v in foo.items()}"
 
         >>> Renderer(TO_ITER).render(SeField(Tuple[str, Foo, int], 'foo'))
-        "(foo[0], foo[1].__serde__.funcs['to_iter'](foo[1], reuse_instances=reuse_instances, convert_sets=convert_sets), foo[2])"
+        "(foo[0], foo[1].__serde__.funcs['to_iter'](foo[1], reuse_instances=reuse_instances, convert_sets=convert_sets), foo[2],)"
         """
         if is_dataclass(arg.type):
             return self.dataclass(arg)
@@ -524,7 +524,7 @@ class Renderer:
                 r = arg[i]
                 r.name = f'{arg.varname}[{i}]'
                 rvalues.append(self.render(r))
-            return f"({', '.join(rvalues)})"
+            return f"({', '.join(rvalues)},)"  # trailing , is required for single element tuples
 
     def dict(self, arg: SeField) -> str:
         """

--- a/serde/se.py
+++ b/serde/se.py
@@ -370,7 +370,7 @@ def {{func}}(obj, reuse_instances = {{serde_scope.reuse_instances_default}}, con
 
 def render_union_func(cls: Type, union_args: List[Type]) -> str:
     template = """
-def {{func}}(obj, reuse_instances):
+def {{func}}(obj, reuse_instances, convert_sets):
   {% for name in serde_scope.types.keys() %}
   {{name}} = serde_scope.types['{{name}}']
   {% endfor %}
@@ -553,7 +553,7 @@ class Renderer:
 
     def union_func(self, arg: SeField) -> str:
         func_name = union_func_name(UNION_SE_PREFIX, type_args(arg.type))
-        return f"serde_scope.funcs['{func_name}']({arg.varname}, reuse_instances)"
+        return f"serde_scope.funcs['{func_name}']({arg.varname}, reuse_instances, convert_sets)"
 
 
 def enum_value(cls, e):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ tests_require = [
     'pytest-flake8',
     'mypy',
     'flake8',
+    'pre-commit',
 ]
 
 setup(

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -377,6 +377,21 @@ def test_tuple(se, de, opt):
 
 
 @pytest.mark.parametrize('se,de', all_formats)
+def test_single_element_tuples(se, de):
+    @deserialize
+    @serialize
+    @dataclass
+    class Foo:
+        a: Tuple[int]
+        b: Tuple[uuid.UUID]
+
+    foo = Foo(a=(1,), b=(uuid.UUID("855f07da-c3cd-46f2-9557-b8dbeb99ff42"),))
+    assert to_dict(foo) == {"a": foo.a, "b": foo.b}
+
+    assert foo == de(Foo, se(foo))
+
+
+@pytest.mark.parametrize('se,de', all_formats)
 def test_dataclass_default_factory(se, de):
     @deserialize
     @serialize

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from ipaddress import IPv4Address
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -290,6 +290,25 @@ def test_union_rename_all():
 
     assert to_dict(Foo(10)) == {'BarBaz': 10}
     assert from_dict(Foo, {'BarBaz': 'foo'}) == Foo('foo')
+
+
+def test_union_with_list_of_other_class():
+    @deserialize
+    @serialize
+    @dataclass
+    class A:
+        a: int
+
+    @deserialize
+    @serialize
+    @dataclass
+    class B:
+        b: Union[List[A], str]
+
+    b = B([A(1)])
+    b_dict = {"b": [{"a": 1}]}
+    assert to_dict(b) == b_dict
+    assert from_dict(B, b_dict) == b
 
 
 # relates to https://github.com/yukinarit/pyserde/issues/113

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from ipaddress import IPv4Address
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Tuple
 from uuid import UUID
 
 import pytest
@@ -309,3 +309,27 @@ def test_union_with_union_in_nested_types():
     assert to_dict(a_int) == {"v": [1]}
     assert a_int == from_dict(A, to_dict(a_int, reuse_instances=False), reuse_instances=False)
     assert a_int == from_dict(A, to_dict(a_int, reuse_instances=True), reuse_instances=True)
+
+
+# relates to https://github.com/yukinarit/pyserde/issues/113
+def test_union_with_union_in_nested_tuple():
+    @deserialize
+    @serialize
+    @dataclass
+    class A:
+        v: Union[bool, Tuple[Union[str, int]]]
+
+    a_bool = A(False)
+    a_bool_dict = {"v": False}
+    assert to_dict(a_bool) == a_bool_dict
+    assert from_dict(A, a_bool_dict) == a_bool
+
+    a_str = A(("a",))
+    a_str_dict = {"v": ("a",)}
+    assert to_dict(a_str) == a_str_dict
+    assert from_dict(A, a_str_dict) == a_str
+
+    a_int = A((1,))
+    a_int_dict = {"v": (1,)}
+    assert to_dict(a_int) == a_int_dict
+    assert from_dict(A, a_int_dict) == a_int

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -290,3 +290,22 @@ def test_union_rename_all():
 
     assert to_dict(Foo(10)) == {'BarBaz': 10}
     assert from_dict(Foo, {'BarBaz': 'foo'}) == Foo('foo')
+
+
+# relates to https://github.com/yukinarit/pyserde/issues/113
+def test_union_with_union_in_nested_types():
+    @deserialize
+    @serialize
+    @dataclass
+    class A:
+        v: Union[UUID, List[Union[UUID, int]]]
+
+    a_uuid = A([UUID("00611ee9-7ca3-41d3-9607-ea7268e264ea")])
+    assert to_dict(a_uuid, reuse_instances=False) == {"v": ["00611ee9-7ca3-41d3-9607-ea7268e264ea"]}
+    assert a_uuid == from_dict(A, to_dict(a_uuid, reuse_instances=False), reuse_instances=False)
+    assert a_uuid == from_dict(A, to_dict(a_uuid, reuse_instances=True), reuse_instances=True)
+
+    a_int = A([1])
+    assert to_dict(a_int) == {"v": [1]}
+    assert a_int == from_dict(A, to_dict(a_int, reuse_instances=False), reuse_instances=False)
+    assert a_int == from_dict(A, to_dict(a_int, reuse_instances=True), reuse_instances=True)


### PR DESCRIPTION
Hi @yukinarit,
I fixed some bugs. Mainly regarding #113

1. Unions with other unions in container types should work now.
2. I also fixed the tuple bug. The problem was that single element tuples where rendered as `("a")`. Which becomes just `"a"` instead of a tuple. The fix was always adding a trailing comma like so `("a",)`.
3. The last bug was that the `convert_sets` argument was not correctly passed to the rendered union functions. Which prevented the use of other dataclasses in a container type within a union.

Closes #113 