### PR TITLE
Parallel test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ build:
 	$(POETRY) build
 
 test:
-	$(POETRY) run pytest tests --doctest-modules serde -v
+	$(POETRY) run pytest tests --doctest-modules serde -v -nauto
 
 examples:
 	pushd examples && $(POETRY) run $(PYTHON) runner.py && popd
 
 coverage:
-	$(POETRY) run pytest tests --doctest-modules serde -v --cov=serde --cov-report term --cov-report xml
+	$(POETRY) run pytest tests --doctest-modules serde -v -nauto --cov=serde --cov-report term --cov-report xml
 
 pep8:
 	$(POETRY) run flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pdoc3 = "~=0.9"
 mypy = {version = "==0.782", markers = "platform_python_implementation!='PyPy'"}
 more-itertools = "~=8.6.0"
 pre-commit = "==v2.10.1"
+pytest-xdist = "^2.3.0"
 
 [tool.poetry.extras]
 msgpack = ["msgpack"]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -91,8 +91,8 @@ types: List = [
     (ipaddress.IPv4Interface("192.168.1.1/24"), ipaddress.IPv4Interface),
     (ipaddress.IPv6Interface("::1/128"), ipaddress.IPv6Interface),
     (decimal.Decimal(10), decimal.Decimal),
-    (datetime.now(), datetime),
-    (date.today(), date),
+    (datetime.strptime('Jan 1 2021 1:55PM', '%b %d %Y %I:%M%p'), datetime),
+    (datetime.strptime('Jan 1 2021 1:55PM', '%b %d %Y %I:%M%p').date(), date),
 ]
 
 # these types can only be instantiated on their corresponding system


### PR DESCRIPTION
Hi!

This is a proposal to add parallel test execution in the project. To make test run in parallel I've "freezed" the `datetime` and `date` objects in test_basics.py (otherwise pytest gets confused).

Tests run 3 times faster on my machine (MacBook Pro 15-inch 2017, 2.8 GHz Quad-Core Intel Core i7, 16 GB 2133 MHz LPDDR3) and there is some time benefit in CI also.

``` sh
# without parallelism
...
serde/se.py::serde.se.to_dict PASSED                                                                                          [ 99%]
serde/se.py::serde.se.to_tuple PASSED                                                                                         [ 99%]
serde/toml.py::serde.toml.from_toml PASSED                                                                                    [ 99%]
serde/toml.py::serde.toml.to_toml PASSED                                                                                      [ 99%]
serde/yaml.py::serde.yaml.from_yaml PASSED                                                                                    [ 99%]
serde/yaml.py::serde.yaml.to_yaml PASSED                                                                                      [100%]

================================================== 1290 passed in 71.81s (0:01:11) ==================================================
```


``` sh
# parallel execution
...
[gw4] [ 99%] PASSED serde/yaml.py::serde.yaml.to_yaml
serde/se.py::serde.se.to_dict
[gw5] [ 99%] PASSED serde/toml.py::serde.toml.to_toml
[gw7] [ 99%] PASSED serde/se.py::serde.se.to_dict
[gw0] [ 99%] PASSED tests/test_basics.py::test_tuple[to_toml-from_toml-reuse_instances_default-False2]
tests/test_basics.py::test_single_element_tuples[to_dict-from_dict]
[gw0] [100%] PASSED tests/test_basics.py::test_single_element_tuples[to_dict-from_dict]

======================================================= 1290 passed in 23.62s =======================================================
```


What do you think?