### PR TITLE
feat: deserialize to the type more correctly

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -285,7 +285,7 @@ def from_obj(c: Type, o: Any, named: bool, reuse_instances: bool):
     elif is_dict(c):
         return {thisfunc(type_args(c)[0], k): thisfunc(type_args(c)[1], v) for k, v in o.items()}
 
-    return o
+    return c(o)
 
 
 def from_dict(cls, o, reuse_instances: bool = ...):

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,9 +1,29 @@
-from typing import Tuple, Union
+from decimal import Decimal
+from typing import List, Tuple, Union
 
 from serde.de import from_obj
 
 
 def test_from_obj():
-    assert not from_obj(int, None, False, True)
-    assert "a" == from_obj(Union[int, str], "a", False, True)
-    assert ("a", "b") == from_obj(Tuple[str, str], ("a", "b"), False, True)
+    # None will be None
+    assert from_obj(int, None, False, False) is None
+
+    # Primitive
+    assert 10 == from_obj(int, 10, False, False)
+
+    # Union
+    assert "a" == from_obj(Union[int, str], "a", False, False)
+
+    # Tuple
+    assert ("a", "b") == from_obj(Tuple[str, str], ("a", "b"), False, False)
+
+    # pyserde converts to the specified type
+    assert 10 == from_obj(int, "10", False, False)
+
+    # pyserde can converts for container types e.g. Tuple, List etc.
+    assert (1, 2) == from_obj(Tuple[int, int], ("1", "2"), False, False)
+
+    # Decimal
+    dec = from_obj(List[Decimal], ("0.1", 0.1), False, False)
+    assert isinstance(dec[0], Decimal) and dec[0] == Decimal("0.1")
+    assert isinstance(dec[1], Decimal) and dec[1] == Decimal(0.1)


### PR DESCRIPTION
pyserde converts to the specified type correctly

e.g. the value is "10" which is string. pyserde passes
"10" in `int` function and deserialize it into 10.

```python
assert 10 == from_tuple(int, "10")
```