### PR TITLE
fix: Use default value only if key isn't present

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -463,11 +463,8 @@ class Renderer:
         else:
             return f"raise_unsupported_type({arg.data})"
 
-        if has_default(arg) or has_default_factory(arg):
-            if arg.iterbased:
-                exists = f'{arg.data} is not None'
-            else:
-                exists = f'"{arg.conv_name()}" in {arg.datavar}'
+        if not arg.iterbased and (has_default(arg) or has_default_factory(arg)):
+            exists = f'"{arg.conv_name()}" in {arg.datavar}'
             if has_default(arg):
                 res = f'({res}) if {exists} else serde_scope.defaults["{arg.name}"]'
             elif has_default_factory(arg):

--- a/serde/de.py
+++ b/serde/de.py
@@ -467,7 +467,7 @@ class Renderer:
             if arg.iterbased:
                 exists = f'{arg.data} is not None'
             else:
-                exists = f'{arg.datavar}.get("{arg.conv_name()}") is not None'
+                exists = f'"{arg.conv_name()}" in {arg.datavar}'
             if has_default(arg):
                 res = f'({res}) if {exists} else serde_scope.defaults["{arg.name}"]'
             elif has_default_factory(arg):

--- a/tests/data.py
+++ b/tests/data.py
@@ -216,6 +216,18 @@ class PriDefault:
     b: bool = True
 
 
+@deserialize
+@serialize
+@dataclass
+class OptDefault:
+    """
+    Optionals.
+    """
+
+    n: Optional[int] = None
+    i: Optional[int] = 10
+
+
 class E(enum.Enum):
     S = 'foo'
     F = 10.0

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 import pytest
 
 import serde
-from serde import SerdeError, deserialize, from_dict, serialize, to_dict
+from serde import SerdeError, deserialize, from_dict, from_tuple, serialize, to_dict
 
 from . import data
 from .common import (
@@ -357,6 +357,7 @@ def test_default(se, de):
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo'})
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo', 'f': 100.0})
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo', 'f': 100.0, 'b': True})
+    assert p == from_tuple(PriDefault, (10, 'foo', 100.0, True))
 
     o = OptDefault()
     assert o == de(OptDefault, se(o))
@@ -365,7 +366,11 @@ def test_default(se, de):
     assert o == from_dict(OptDefault, {})
     assert o == from_dict(OptDefault, {"n": None})
     assert o == from_dict(OptDefault, {"n": None, "i": 10})
-    assert OptDefault(n=None, i=None) == from_dict(OptDefault, {"n": None, "i": None})
+    assert o == from_tuple(OptDefault, (None, 10))
+
+    o = OptDefault(n=None, i=None)
+    assert o == from_dict(OptDefault, {"n": None, "i": None})
+    assert o == from_tuple(OptDefault, (None, None))
 
     assert 10 == dataclasses.fields(PriDefault)[0].default
     assert 'foo' == dataclasses.fields(PriDefault)[1].default

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -346,7 +346,7 @@ def test_dataclass_default_factory(se, de):
 
 @pytest.mark.parametrize('se,de', all_formats)
 def test_default(se, de):
-    from .data import PriDefault
+    from .data import OptDefault, PriDefault
 
     p = PriDefault()
     assert p == de(PriDefault, se(p))
@@ -357,6 +357,15 @@ def test_default(se, de):
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo'})
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo', 'f': 100.0})
     assert p == from_dict(PriDefault, {'i': 10, 's': 'foo', 'f': 100.0, 'b': True})
+
+    o = OptDefault()
+    assert o == de(OptDefault, se(o))
+
+    o = OptDefault()
+    assert o == from_dict(OptDefault, {})
+    assert o == from_dict(OptDefault, {"n": None})
+    assert o == from_dict(OptDefault, {"n": None, "i": 10})
+    assert OptDefault(n=None, i=None) == from_dict(OptDefault, {"n": None, "i": None})
 
     assert 10 == dataclasses.fields(PriDefault)[0].default
     assert 'foo' == dataclasses.fields(PriDefault)[1].default


### PR DESCRIPTION
Fixes #166 for dict. Tuple behavior is unchanged.