### PR TITLE
refactor: Remove type references from SerdeScope

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -92,9 +92,6 @@ class SerdeScope:
     defaults: Dict[str, Union[Callable, Any]] = field(default_factory=dict)
     """ Default values of the dataclass fields (factories & normal values) """
 
-    types: Dict[str, Type] = field(default_factory=dict)
-    """ Type references to all used types within the dataclass """
-
     code: Dict[str, str] = field(default_factory=dict)
     """ Generated source code (only filled when debug is True) """
 
@@ -134,14 +131,6 @@ class SerdeScope:
             res.append(self._justify('Default values for the dataclass fields'))
             res.append('--------------------------------------------------')
             for k, v in self.defaults.items():
-                res.append(f'{k}: {v}')
-            res.append('')
-
-        if self.types:
-            res.append('--------------------------------------------------')
-            res.append(self._justify('Type references in scope'))
-            res.append('--------------------------------------------------')
-            for k, v in self.types.items():
                 res.append(f'{k}: {v}')
             res.append('')
 

--- a/serde/de.py
+++ b/serde/de.py
@@ -171,8 +171,6 @@ def deserialize(
         for typ in iter_types(cls):
             if typ is cls or (is_primitive(typ) and not is_enum(typ)):
                 continue
-
-            scope.types[typename(typ)] = typ
             g[typename(typ)] = typ
 
         # render all union functions
@@ -661,11 +659,6 @@ def {{func}}(data, reuse_instances = {{serde_scope.reuse_instances_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{serde_scope.reuse_instances_default}}
 
-  {# List up all classes used by this class. -#}
-  {% for name in serde_scope.types|filter_scope -%}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor -%}
-
   if data is None:
     return None
 
@@ -690,11 +683,6 @@ def {{func}}(data, reuse_instances = {{serde_scope.reuse_instances_default}}):
   if reuse_instances is Ellipsis:
     reuse_instances = {{serde_scope.reuse_instances_default}}
 
-  {# List up all classes used by this class. #}
-  {% for name in serde_scope.types|filter_scope %}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor %}
-
   if data is None:
     return None
 
@@ -716,10 +704,6 @@ def {{func}}(data, reuse_instances = {{serde_scope.reuse_instances_default}}):
 def render_union_func(cls: Type, union_args: List[Type]) -> str:
     template = """
 def {{func}}(data, reuse_instances):
-  {% for name in serde_scope.types|filter_scope %}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor %}
-
   # create fake dict so we can reuse the normal render function
   fake_dict = {"fake_key":data}
 

--- a/serde/se.py
+++ b/serde/se.py
@@ -183,8 +183,6 @@ def serialize(
         for typ in iter_types(cls):
             if typ is cls or (is_primitive(typ) and not is_enum(typ)):
                 continue
-
-            scope.types[typename(typ)] = typ
             g[typename(typ)] = typ
 
         # render all union functions
@@ -374,11 +372,6 @@ def {{func}}(obj, reuse_instances = {{serde_scope.reuse_instances_default}},
   if not is_dataclass(obj):
     return copy.deepcopy(obj)
 
-  {# List up all classes used by this class. #}
-  {% for name in serde_scope.types|filter_scope %}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor %}
-
   return (
   {% for f in fields -%}
   {% if not f.skip|default(False) %}
@@ -407,11 +400,6 @@ def {{func}}(obj, reuse_instances = {{serde_scope.reuse_instances_default}},
   if not is_dataclass(obj):
     return copy.deepcopy(obj)
 
-  {# List up all classes used by this class. #}
-  {% for name in serde_scope.types|filter_scope -%}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor -%}
-
   res = {}
   {% for f in fields -%}
   {% if not f.skip -%}
@@ -439,10 +427,6 @@ def {{func}}(obj, reuse_instances = {{serde_scope.reuse_instances_default}},
 def render_union_func(cls: Type, union_args: List[Type]) -> str:
     template = """
 def {{func}}(obj, reuse_instances, convert_sets):
-  {% for name in serde_scope.types|filter_scope %}
-  {{name}} = serde_scope.types['{{name}}']
-  {% endfor %}
-
   union_args = serde_scope.union_se_args['{{func}}']
 
   {% for t in union_args %}


### PR DESCRIPTION
References to types used in generated functions are now added to
global scope of `exec` function. No need to have `types` property
in SerdeScope object anymore.