### PR TITLE
fix: raise SerdeError from serde's APIs

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -16,7 +16,7 @@ __all__: List = []
 T = TypeVar('T')
 
 
-class SerdeError(TypeError):
+class SerdeError(Exception):
     """
     Serde error class.
     """

--- a/serde/se.py
+++ b/serde/se.py
@@ -232,7 +232,7 @@ def serialize(
         add_func(scope, TO_ITER, render_to_tuple(cls, serializer), g)
         add_func(scope, TO_DICT, render_to_dict(cls, rename_all, serializer), g)
 
-        logger.debug(f'{cls.__name__}: {SERDE_SCOPE} {scope}')
+        logger.debug(f'{typename(cls)}: {SERDE_SCOPE} {scope}')
 
         return cls
 
@@ -690,7 +690,7 @@ convert_sets=convert_sets), foo[2],)"
             return f'{{{self.render(karg)}: {self.render(varg)} for k, v in {arg.varname}.items()}}'
 
     def enum(self, arg: SeField) -> str:
-        return f'enum_value({arg.type.__name__}, {arg.varname})'
+        return f'enum_value({typename(arg.type)}, {arg.varname})'
 
     def primitive(self, arg: SeField) -> str:
         """

--- a/serde/se.py
+++ b/serde/se.py
@@ -262,34 +262,38 @@ def is_serializable(instance_or_class: Any) -> bool:
 
 
 def to_obj(o, named: bool, reuse_instances: bool, convert_sets: bool):
-    thisfunc = functools.partial(to_obj, named=named, reuse_instances=reuse_instances, convert_sets=convert_sets)
-    if o is None:
-        return None
-    if is_serializable(o):
-        serde_scope: SerdeScope = getattr(o, SERDE_SCOPE)
-        if named:
-            return serde_scope.funcs[TO_DICT](o, reuse_instances=reuse_instances, convert_sets=convert_sets)
-        else:
-            return serde_scope.funcs[TO_ITER](o, reuse_instances=reuse_instances, convert_sets=convert_sets)
-    elif is_dataclass(o):
-        if named:
-            return dataclasses.asdict(o)
-        else:
-            return dataclasses.astuple(o)
-    elif isinstance(o, list):
-        return [thisfunc(e) for e in o]
-    elif isinstance(o, tuple):
-        return tuple(thisfunc(e) for e in o)
-    elif isinstance(o, set):
-        return [thisfunc(e) for e in o]
-    elif isinstance(o, dict):
-        return {k: thisfunc(v) for k, v in o.items()}
-    elif isinstance(o, StrSerializableTypes):
-        return str(o)
-    elif isinstance(o, DateTimeTypes):
-        return o.isoformat()
+    try:
+        thisfunc = functools.partial(to_obj, named=named, reuse_instances=reuse_instances, convert_sets=convert_sets)
+        if o is None:
+            return None
+        if is_serializable(o):
+            serde_scope: SerdeScope = getattr(o, SERDE_SCOPE)
+            if named:
+                return serde_scope.funcs[TO_DICT](o, reuse_instances=reuse_instances, convert_sets=convert_sets)
+            else:
+                return serde_scope.funcs[TO_ITER](o, reuse_instances=reuse_instances, convert_sets=convert_sets)
+        elif is_dataclass(o):
+            if named:
+                return dataclasses.asdict(o)
+            else:
+                return dataclasses.astuple(o)
+        elif isinstance(o, list):
+            return [thisfunc(e) for e in o]
+        elif isinstance(o, tuple):
+            return tuple(thisfunc(e) for e in o)
+        elif isinstance(o, set):
+            return [thisfunc(e) for e in o]
+        elif isinstance(o, dict):
+            return {k: thisfunc(v) for k, v in o.items()}
+        elif isinstance(o, StrSerializableTypes):
+            return str(o)
+        elif isinstance(o, DateTimeTypes):
+            return o.isoformat()
 
-    return o
+        return o
+
+    except Exception as e:
+        raise SerdeError(e)
 
 
 def astuple(v):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -625,3 +625,15 @@ def test_make_serialize_deserialize(se):
     f = Foo(Bar(10))
     assert serde.to_dict(f) == {'bar': {'v': 10}}
     assert serde.from_dict(Foo, {'bar': {'v': 10}}) == f
+
+
+def test_exception_to_from_obj():
+    @serde.serde
+    class Foo:
+        a: int
+
+    class Bar:
+        pass
+
+    with pytest.raises(serde.SerdeError):
+        serde.from_dict(Foo, {})

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 
 import pytest
 
-from serde import SerdeSkip, default_deserializer, default_serializer, field, from_tuple, serde, to_tuple
+from serde import SerdeError, SerdeSkip, default_deserializer, default_serializer, field, from_tuple, serde, to_tuple
 from serde.json import from_json, to_json
 
 
@@ -54,10 +54,10 @@ def test_wrong_signature():
         i: int = field(serializer=lambda: '10', deserializer=lambda: 10)
 
     f = Foo(10)
-    with pytest.raises(TypeError):
+    with pytest.raises(SerdeError):
         to_json(f)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(SerdeError):
         from_json(Foo, '{"i": 10}')
 
 


### PR DESCRIPTION
It's convenient and consistent that serde always raises SerdeError
exception if ever something happens in serde code. Sorry, this fix
also changes the base type of SerdeError from TypeError to
Exception.

I'm aware that some API such as `to_msgpack` still potentially
raises other type of exceptions. Let me fix that little by little.