### PR TITLE
feat: Add _make_serialize and _make_deserialize

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -455,6 +455,21 @@ class Field:
             flatten=flatten,
         )
 
+    def to_dataclass(self) -> dataclasses.Field:
+        f = dataclasses.Field(
+            default=self.default,
+            default_factory=self.default_factory,
+            init=self.init,
+            repr=self.repr,
+            hash=self.hash,
+            compare=self.compare,
+            metadata=self.metadata,
+        )
+        assert self.name
+        f.name = self.name
+        f.type = self.type
+        return f
+
     @staticmethod
     def mangle(field: dataclasses.Field, name: str) -> str:
         """

--- a/serde/de.py
+++ b/serde/de.py
@@ -4,6 +4,7 @@ associated with deserialization.
 """
 
 import abc
+import dataclasses
 import functools
 from dataclasses import dataclass, is_dataclass
 from typing import Any, Callable, Dict, List, Optional, Type
@@ -77,6 +78,31 @@ def default_deserializer(_cls: Type, obj):
     Marker function to tell serde to use the default deserializer. It's used when custom deserializer is specified
     at the class but you want to override a field with the default deserializer.
     """
+
+
+def _make_deserialize(
+    cls_name: str,
+    fields,
+    *args,
+    rename_all: Optional[str] = None,
+    reuse_instances_default: bool = True,
+    convert_sets_default: bool = False,
+    serializer: Optional[DeserializeFunc] = None,
+    **kwargs,
+):
+    """
+    Create a deserializable class programatically.
+    """
+    C = dataclasses.make_dataclass(cls_name, fields, *args, **kwargs)
+    C = deserialize(
+        C,
+        *args,
+        rename_all=rename_all,
+        reuse_instances_default=reuse_instances_default,
+        convert_sets_default=convert_sets_default,
+        **kwargs,
+    )
+    return C
 
 
 def deserialize(

--- a/serde/se.py
+++ b/serde/se.py
@@ -85,6 +85,31 @@ class Serializer(metaclass=abc.ABCMeta):
         pass
 
 
+def _make_serialize(
+    cls_name: str,
+    fields,
+    *args,
+    rename_all: Optional[str] = None,
+    reuse_instances_default: bool = True,
+    convert_sets_default: bool = False,
+    serializer: Optional[SerializeFunc] = None,
+    **kwargs,
+):
+    """
+    Create a serializable class programatically.
+    """
+    C = dataclasses.make_dataclass(cls_name, fields, *args, **kwargs)
+    C = serialize(
+        C,
+        *args,
+        rename_all=rename_all,
+        reuse_instances_default=reuse_instances_default,
+        convert_sets_default=convert_sets_default,
+        **kwargs,
+    )
+    return C
+
+
 def serialize(
     _cls=None,
     rename_all: Optional[str] = None,


### PR DESCRIPTION
Allows creating (de)serializable class programatically
Currently those APIs are experimental and private, used to
fulfill the purpose of implementing Union tagging system.

I may be going to make it public someday.