### PR TITLE
Fix Optional in custom class deserializer

### DIFF
--- a/docs/features/custom-field-serializer.md
+++ b/docs/features/custom-field-serializer.md
@@ -1,16 +1,15 @@
 # Custom field (de)serializer
 
-If you want to provide a custom function to override the default (de)serialization behaviour of a field, you can pass your functions to `serde_serializer` and `serde_deserializer` dataclass metadata.
+If you want to provide a custom function to override the default (de)serialization behaviour of a field, you can pass your functions to `serializer` and `deserializer` in `serde.field`.
 
 ```python
+from serde import serde, field
+
 @serde
 class Foo:
     dt1: datetime
     dt2: datetime = field(
-        metadata={
-            'serde_serializer': lambda x: x.strftime('%d/%m/%y'),
-            'serde_deserializer': lambda x: datetime.strptime(x, '%d/%m/%y'),
-        }
+        serializer=lambda x: x.strftime('%d/%m/%y'), deserializer=lambda x: datetime.strptime(x, '%d/%m/%y')
     )
 ```
 `dt1` in the example will serialized into `2021-01-01T00:00:00` because the pyserde's default (de)serializier for datetime is ISO 8601. `dt2` field in the example will be serialized into `01/01/21` by the custom field serializer.

--- a/serde/core.py
+++ b/serde/core.py
@@ -19,6 +19,8 @@ import stringcase
 from .compat import (
     SerdeError,
     dataclass_fields,
+    has_default,
+    has_default_factory,
     is_bare_dict,
     is_bare_list,
     is_bare_set,
@@ -484,6 +486,9 @@ class Field:
         are made. Use `name` property to get a field name before conversion.
         """
         return conv(self, case or self.case)
+
+    def supports_default(self) -> bool:
+        return not getattr(self, "iterbased", False) and (has_default(self) or has_default_factory(self))
 
 
 F = TypeVar('F', bound=Field)


### PR DESCRIPTION
This serde Foo class works as expected.

```python
def fallback(_, __):
    raise SerdeSkip()

@serde(serializer=fallback, deserializer=fallback)
class Foo:
    a: Optional[str]
```
