### PR TITLE
core: use black formatting only if debug is enabled

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -162,12 +162,14 @@ def gen(code: str, globals: Dict = None, locals: Dict = None) -> str:
     """
     A wrapper of builtin `exec` function.
     """
-    try:
-        from black import FileMode, format_str
+    if SETTINGS['debug']:
+        # black formatting is only important when debugging
+        try:
+            from black import FileMode, format_str
 
-        code = format_str(code, mode=FileMode(line_length=100))
-    except Exception:
-        pass
+            code = format_str(code, mode=FileMode(line_length=100))
+        except Exception:
+            pass
     exec(code, globals, locals)
     return code
 


### PR DESCRIPTION
There is currently  a small issue on black which makes it try to rebuild is cache forever.

```
Generating grammar tables from site-packages/blib2to3/Grammar.txt
Writing grammar tables to  Grammar3.10.1.final.0.pickle
Writing failed: [Errno 2] No such file or directory: 'XXX/black/21.10b0/tmpi9dlr3sd'
```
This is how I saw that the generated code was actually using black formatting before compile.
Not sure why it is necesarry, but probably it is only needed for debugging.
