### PR TITLE
Add support for orjson, including direct numpy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Foo(i=10, s='foo', f=100.0, b=True)
 - Supported data formats
     - dict
     - tuple
-    - JSON
+    - JSON (via `json` or `orjson` packages)
 	- Yaml
 	- Toml
 	- MsgPack

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,8 @@ Next, import pyserde (de)serialize API. For JSON:
 
 ```python
 from serde.json import from_json, to_json
+# OR:
+# from serde.orjson import from_json, to_json
 ```
 
 Similarly, you can use other data formats.

--- a/docs/supported-data-formats.md
+++ b/docs/supported-data-formats.md
@@ -50,6 +50,42 @@ Call `to_json` to serialize `Foo` object into JSON string and `from_json` to des
 Foo(i=10, s='foo', f=100.0, b=True)
 ```
 
+### Orjson
+
+Orjson is a fast alternative to the standard json library.  It is implemented as separate sub-module because it's behavior is slightly different than the standard library.
+
+```python
+>>> from serde.orjson import to_json, from_json
+
+>>> to_json(Foo(i=10, s='foo', f=100.0, b=True))   # Note: produces a byte object
+b'{"i":10,"s":"foo","f":100.0,"b":true}'
+
+>>> to_json(Foo(i=10, s='foo', f=100.0, b=True)).decode("utf-8")
+'{"i":10,"s":"foo","f":100.0,"b":true}'
+
+>>> from_json(Foo, '{"i": 10, "s": "foo", "f": 100.0, "b": true}')
+Foo(i=10, s='foo', f=100.0, b=True)
+
+>>> from_json(Foo, b'{"i": 10, "s": "foo", "f": 100.0, "b": true}')
+Foo(i=10, s='foo', f=100.0, b=True)
+```
+
+#### Orjson Limitations
+
+* By default, dataclass objects are passed directly to orjson for serialization.  However, `orjson` does not recognize [`serde.field`](https://yukinarit.github.io/pyserde/guide/features/attributes.html#serdefield) attributes.  If you use these, you can have `pyserde` encode them for you:
+
+```python
+from serde import field, serde
+from serde.orjson import to_json
+
+@serde
+class Foo:
+    class_name: str = field(rename='class')
+
+s = to_json(Foo("MyFoo"))               # b'{"class_name":"MyFoo"}'
+t = to_json(Foo("MyFoo"), direct=False) # b'{"class":"MyFoo"}
+```
+
 ## Yaml
 
 Call `to_yaml` to serialize `Foo` object into Yaml string and `from_yaml` to deserialize Yaml string into `Foo` object. For more information, please visit [serde.yaml](https://yukinarit.github.io/pyserde/api/serde/yaml.html) module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,12 @@ numpy = [
     { version = ">1.21.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]
+orjson = [
+    { version = ">3.0.0", markers = "python_version ~= '3.7.0' and (extra == 'orjson' or extra == 'all')", optional = true },
+    { version = ">3.0.0", markers = "python_version ~= '3.8.0' and (extra == 'orjson' or extra == 'all')", optional = true },
+    { version = ">3.0.0", markers = "python_version ~= '3.9.0' and (extra == 'orjson' or extra == 'all')", optional = true },
+    { version = ">3.4.7", markers = "python_version ~= '3.10' and (extra == 'orjson' or extra == 'all')", optional = true },
+]
 
 [tool.poetry.dev-dependencies]
 pyyaml = "*"
@@ -47,6 +53,12 @@ numpy = [
     { version = ">1.21.0", markers = "python_version ~= '3.8.0'" },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0'" },
     { version = ">1.22.0", markers = "python_version ~= '3.10'" },
+]
+orjson = [
+    { version = ">3.0.0", markers = "python_version ~= '3.7.0'" },
+    { version = ">3.0.0", markers = "python_version ~= '3.8.0'" },
+    { version = ">3.0.0", markers = "python_version ~= '3.9.0'" },
+    { version = ">3.4.7", markers = "python_version ~= '3.10'" },
 ]
 flake8 = "*"
 pytest = "*"
@@ -59,13 +71,15 @@ mypy = { version = "==0.931", markers = "platform_python_implementation!='PyPy'"
 more-itertools = "~=8.6.0"
 pre-commit = "==v2.10.1"
 pytest-xdist = "^2.3.0"
+types-orjson = "*"
 
 [tool.poetry.extras]
 msgpack = ["msgpack"]
 numpy = ["numpy"]
+orjson = ["orjson"]
 toml = ["toml"]
 yaml = ["pyyaml"]
-all = ["msgpack", "toml", "pyyaml", "numpy"]
+all = ["msgpack", "toml", "pyyaml", "numpy", "orjson"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/serde/core.py
+++ b/serde/core.py
@@ -110,6 +110,10 @@ class SerdeScope:
     """ Default values for to_dict & from_dict arguments """
 
     convert_sets_default: bool = False
+    """ Convert sets to lists """
+
+    convert_numpy_default: bool = True
+    """ Convert numpy types to python types """
 
     def __repr__(self) -> str:
         res: List[str] = []

--- a/serde/de.py
+++ b/serde/de.py
@@ -104,7 +104,7 @@ def _make_deserialize(
     rename_all: Optional[str] = None,
     reuse_instances_default: bool = True,
     convert_sets_default: bool = False,
-    serializer: Optional[DeserializeFunc] = None,
+    deserializer: Optional[DeserializeFunc] = None,
     **kwargs,
 ):
     """
@@ -117,6 +117,7 @@ def _make_deserialize(
         rename_all=rename_all,
         reuse_instances_default=reuse_instances_default,
         convert_sets_default=convert_sets_default,
+        deserializer=deserializer,
         **kwargs,
     )
     return C

--- a/serde/numpy.py
+++ b/serde/numpy.py
@@ -53,7 +53,7 @@ try:
             return False
 
     def serialize_numpy_scalar(arg) -> str:
-        return f"{arg.varname}.item()"
+        return f"{arg.varname}.item() if convert_numpy else {arg.varname}"
 
     def deserialize_numpy_scalar(arg):
         return f"{fullname(arg.type)}({arg.data})"
@@ -65,7 +65,7 @@ try:
         return typ is np.ndarray
 
     def serialize_numpy_array(arg) -> str:
-        return f"{arg.varname}.tolist()"
+        return f"{arg.varname}.tolist() if convert_numpy else {arg.varname}"
 
     def serialize_numpy_datetime(arg) -> str:
         return f"{arg.varname}.item().isoformat()"
@@ -83,6 +83,8 @@ try:
 
         dtype = get_args(get_args(typ)[1])[0]
         return np.array(arg, dtype=dtype)
+
+    HAVE_NUMPY = True
 
 except ImportError:
     encode_numpy = None
@@ -113,3 +115,5 @@ except ImportError:
 
     def deserialize_numpy_array_direct(typ, arg):
         return arg
+
+    HAVE_NUMPY = False

--- a/serde/orjson.py
+++ b/serde/orjson.py
@@ -1,0 +1,104 @@
+"""
+Serialize and Deserialize in JSON format using orjson.
+"""
+from typing import Any, Type, Union
+
+import orjson
+from orjson import (
+    OPT_APPEND_NEWLINE,
+    OPT_INDENT_2,
+    OPT_NAIVE_UTC,
+    OPT_NON_STR_KEYS,
+    OPT_OMIT_MICROSECONDS,
+    OPT_PASSTHROUGH_DATACLASS,
+    OPT_PASSTHROUGH_DATETIME,
+    OPT_PASSTHROUGH_SUBCLASS,
+    OPT_SERIALIZE_NUMPY,
+    OPT_SORT_KEYS,
+    OPT_STRICT_INTEGER,
+    OPT_UTC_Z,
+)
+
+from .compat import T
+from .core import StrSerializableTypes
+from .de import Deserializer, from_dict
+from .numpy import HAVE_NUMPY
+from .se import Serializer, to_dict
+
+__all__ = [
+    "from_json",
+    "to_json",
+    "OPT_APPEND_NEWLINE",
+    "OPT_INDENT_2",
+    "OPT_NAIVE_UTC",
+    "OPT_NON_STR_KEYS",
+    "OPT_OMIT_MICROSECONDS",
+    "OPT_PASSTHROUGH_DATACLASS",
+    "OPT_PASSTHROUGH_DATETIME",
+    "OPT_PASSTHROUGH_SUBCLASS",
+    "OPT_SERIALIZE_NUMPY",
+    "OPT_SORT_KEYS",
+    "OPT_STRICT_INTEGER",
+    "OPT_UTC_Z",
+]
+
+
+class OrjsonSerializer(Serializer):
+    @classmethod
+    def serialize(cls, obj: Any, **opts) -> bytes:
+        return orjson.dumps(obj, **opts)
+
+
+class OrjsonDeserializer(Deserializer):
+    @classmethod
+    def deserialize(cls, s, **opts):
+        return orjson.loads(s, **opts)
+
+
+def default(obj: Any):
+    if isinstance(obj, StrSerializableTypes):
+        return str(obj)
+    if isinstance(obj, set):
+        return list(obj)
+
+    raise TypeError(f"Type is not JSON serializable: {type(obj)}")
+
+
+def to_json(obj: Any, se: Type[Serializer] = OrjsonSerializer, direct: bool = True, **opts) -> bytes:
+    """
+    Serialize the object into JSON.
+
+    You can pass any serializable `obj`. If you supply other keyword arguments, they will be passed to the
+    `json.dumps` function.
+
+    By default, `direct=False` means that dataclass objects will first be converted to a dictionary before
+    passing them to orjson.
+
+    Passing `direct=True` passes dataclass objects directly to orjson for serialization.  In almost all cases,
+    this will be faster, but will
+
+    In most cases, `direct=False` will be slower, but may be necessary in rare situations.
+    """
+    if HAVE_NUMPY:
+        opts["option"] = opts.get("option", 0) | OPT_SERIALIZE_NUMPY
+
+    if direct:
+        if "default" not in opts:
+            opts["default"] = default
+        return se.serialize(obj, **opts)
+
+    return se.serialize(to_dict(obj, reuse_instances=False, convert_sets=True, convert_numpy=False), **opts)
+
+
+def from_json(
+    c: Type[T], s: Union[str, bytes, bytearray, memoryview], de: Type[Deserializer] = OrjsonDeserializer, **opts
+) -> T:
+    """
+    Deserialize from JSON into the object.
+
+    `c` is a class object and `s` is JSON string.  If you supply other keyword arguments, they will be passed to
+    the `json.loads` function.
+
+    If you want to use another json package, you can subclass `JsonDeserializer` and implement your own logic.
+    """
+    return from_dict(c, de.deserialize(s, **opts), reuse_instances=False)  # type: ignore

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,8 @@ import more_itertools
 from serde import from_dict, from_tuple, serde, to_dict, to_tuple
 from serde.json import from_json, to_json
 from serde.msgpack import from_msgpack, to_msgpack
+from serde.orjson import from_json as from_orjson
+from serde.orjson import to_json as to_orjson
 from serde.toml import from_toml, to_toml
 from serde.yaml import from_yaml, to_yaml
 from tests import data
@@ -23,13 +25,17 @@ format_tuple: List = [(to_tuple, from_tuple)]
 
 format_json: List = [(to_json, from_json)]
 
+format_orjson: List = [(to_orjson, from_orjson)]
+
 format_msgpack: List = [(to_msgpack, from_msgpack)]
 
 format_yaml: List = [(to_yaml, from_yaml)]
 
 format_toml: List = [(to_toml, from_toml)]
 
-all_formats: List = format_dict + format_tuple + format_json + format_msgpack + format_yaml + format_toml
+all_formats: List = (
+    format_dict + format_tuple + format_json + format_orjson + format_msgpack + format_yaml + format_toml
+)
 
 T = TypeVar('T')
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -6,19 +6,22 @@ from typing import Dict, List
 
 import pytest
 
-from serde import field, serde
+import serde
+from serde import field
 from serde.json import from_json, to_json
+from serde.orjson import from_json as from_orjson
+from serde.orjson import to_json as to_orjson
 
 from .common import all_formats
 
 
-def test_flatten_simple():
-    @serde
+def test_flatten_simple_json():
+    @serde.serde
     class Bar:
         c: float
         d: bool
 
-    @serde
+    @serde.serde
     class Foo:
         a: int
         b: str
@@ -30,24 +33,44 @@ def test_flatten_simple():
     assert from_json(Foo, s) == f
 
 
+def test_flatten_simple_orjson():
+    @serde.serde
+    class Bar:
+        c: float
+        d: bool
+
+    @serde.serde
+    class Foo:
+        a: int
+        b: str
+        bar: Bar = field(flatten=True)
+
+    f = Foo(a=10, b='foo', bar=Bar(c=100.0, d=True))
+    s = b'{"a":10,"b":"foo","c":100.0,"d":true}'
+    assert to_orjson(f, direct=False) == s
+    assert from_orjson(Foo, s) == f
+
+
 @pytest.mark.parametrize('se,de', all_formats)
 def test_flatten(se, de):
-    @serde
+    @serde.serde
     class Baz:
         e: List[int]
         f: Dict[str, str]
 
-    @serde
+    @serde.serde
     class Bar:
         c: float
         d: bool
         baz: Baz = field(flatten=True)
 
-    @serde
+    @serde.serde
     class Foo:
         a: int
         b: str
         bar: Bar = field(flatten=True)
 
     f = Foo(a=10, b='foo', bar=Bar(c=100.0, d=True, baz=Baz([1, 2], {"a": 10})))
-    assert de(Foo, se(f)) == f
+
+    se_f = se(f, direct=False) if se == serde.orjson.to_json else se(f)
+    assert de(Foo, se_f) == f

--- a/tests/test_literal.py
+++ b/tests/test_literal.py
@@ -137,7 +137,7 @@ DictLiterals = Dict[str, Literals]
 @pytest.mark.parametrize("se,de", all_formats)
 def test_dict(se, de, opt):
 
-    if se in (serde.json.to_json, serde.msgpack.to_msgpack, serde.toml.to_toml):
+    if se in (serde.json.to_json, serde.msgpack.to_msgpack, serde.toml.to_toml, serde.orjson.to_json):
         # JSON, Msgpack, Toml don't allow non string key.
         p = LitStrDict({"1": 2}, {"foo": "bar"}, {"True": True}, {"foo": True})
         assert p == de(LitStrDict, se(p))
@@ -182,6 +182,12 @@ def test_json():
     p = Literals(1, "foo", True, "bar")
     s = '{"i": 1, "s": "foo", "b": true, "m": "bar"}'
     assert s == serde.json.to_json(p)
+
+
+def test_orjson():
+    p = Literals(1, "foo", True, "bar")
+    s = b'{"i":1,"s":"foo","b":true,"m":"bar"}'
+    assert s == serde.orjson.to_json(p)
 
 
 def test_msgpack():


### PR DESCRIPTION
This pull request builds on #209, adding support for orjson and modifying numpy support to pass values through to orjson when that module is chosen as the (de)serializer and the appropriate flags are passed.

Still needs tests and probably discussion around how much of orjson to pull in.