### PR TITLE
ci: Use pypy-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
         os: [ubuntu-20.04, macos-10.15, windows-2019]
     steps:
     - name: Checkout


### PR DESCRIPTION
It appears Github Actions uses CPython 3.7 instead of pypy>=3.7.

https://github.com/yukinarit/pyserde/pull/209#issuecomment-1079618722