### PR TITLE
fix: Add dataclass decorator for all example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Declare a class with pyserde's `@serde` decorator.
 
 ```python
 @serde
+@dataclass
 class Foo:
     i: int
     s: str

--- a/docs/features/attributes.md
+++ b/docs/features/attributes.md
@@ -15,9 +15,11 @@ Field attributes are options to customize (de)serialization behaviour specific t
 You can specify field attributes as keyword argument in `serde.field`. See [serde.core.Field](https://yukinarit.github.io/pyserde/api/serde/core.html#Field) for available field attributes. This is recommended way since pyserde v0.6. Use `dataclasses.field` below if you are using pyserde < v0.6.
 
 ```python
+from dataclasses import dataclass
 from serde import field, serde
 
 @serde
+@dataclass
 class Foo:
     class_name: str = field(rename='class')
 ```

--- a/docs/features/case-conversion.md
+++ b/docs/features/case-conversion.md
@@ -4,6 +4,7 @@ Converting `snake_case` fields into supported case styles e.g. `camelCase` and `
 
 ```python
 @serde(rename_all = 'camelcase')
+@dataclass
 class Foo:
     int_field: int
     str_field: str

--- a/docs/features/conditional-skip.md
+++ b/docs/features/conditional-skip.md
@@ -6,6 +6,7 @@ If you conditionally skip some fields, you can pass function or lambda in `skip_
 
 ```python
 @serde
+@dataclass
 class World:
     player: str
     buddy: str = field(default='', skip_if=lambda v: v == 'Pikachu')

--- a/docs/features/custom-class-serializer.md
+++ b/docs/features/custom-class-serializer.md
@@ -16,6 +16,7 @@ def deserializer(cls, o):
         raise SerdeSkip()
 
 @serde(serializer=serializer, deserializer=deserializer)
+@dataclass
 class Foo:
     i: int
     dt1: datetime

--- a/docs/features/custom-field-serializer.md
+++ b/docs/features/custom-field-serializer.md
@@ -3,15 +3,17 @@
 If you want to provide a custom function to override the default (de)serialization behaviour of a field, you can pass your functions to `serializer` and `deserializer` in `serde.field`.
 
 ```python
+from dataclasses import dataclass
 from serde import serde, field
 
 @serde
+@dataclass
 class Foo:
     dt1: datetime
     dt2: datetime = field(
         serializer=lambda x: x.strftime('%d/%m/%y'), deserializer=lambda x: datetime.strptime(x, '%d/%m/%y')
     )
 ```
-`dt1` in the example will serialized into `2021-01-01T00:00:00` because the pyserde's default (de)serializier for datetime is ISO 8601. `dt2` field in the example will be serialized into `01/01/21` by the custom field serializer.
+`dt1` in the example will serialized into `2021-01-01T00:00:00` because the pyserde's default (de)serializer for datetime is ISO 8601. `dt2` field in the example will be serialized into `01/01/21` by the custom field serializer.
 
 For complete example, please see [examples/custom_field_serializer.py](https://github.com/yukinarit/pyserde/blob/master/examples/custom_field_serializer.py)

--- a/docs/features/decorators.md
+++ b/docs/features/decorators.md
@@ -5,6 +5,7 @@
 @serde is a shortcut of @serialize and @deserialize decorators. This code
 ```python
 @serde
+@dataclass
 class Foo:
     ...
 ```
@@ -14,6 +15,7 @@ is equivalent to the following code.
 ```python
 @deserialize
 @serialize
+@dataclass
 class Foo:
     ...
 ```
@@ -26,18 +28,21 @@ class Foo:
 
 ```python
 @serde(serializer=serializer, deserializer=deserializer)
+@dataclass
 class Foo:
     ...
 ```
 
-* If you want to have extra attributes to the dataclass decorator, you can have both `@dataclass` and `@serde` decorators
+> **Note:** `@serde` actually works without @dataclass decorator, because it detects and add @dataclass to the declared class automatically. However, mypy will produce `Too many arguments` or `Unexpected keyword argument` error. This is due to the current mypy limitation. See the following documentation for more information.
+https://mypy.readthedocs.io/en/stable/additional_features.html#caveats-known-issues
+>
+>
+> ```python
+> @serde
+> class Foo:
+>     ...
+> ```
 
-```python
-@serde
-@dataclass(unsafe_hash=True)
-class Foo:
-    ...
-```
 
 ## `@serialize`/`@deserialize`
 

--- a/docs/features/flatten.md
+++ b/docs/features/flatten.md
@@ -4,11 +4,13 @@ You can flatten the fields of the nested structure.
 
 ```python
 @serde
+@dataclass
 class Bar:
     c: float
     d: bool
 
 @serde
+@dataclass
 class Foo:
     a: int
     b: str

--- a/docs/features/forward-reference.md
+++ b/docs/features/forward-reference.md
@@ -3,12 +3,14 @@
 You can use a forward reference in annotations.
 
 ```python
+@dataclass
 class Foo:
     i: int
     s: str
     bar: 'Bar'  # Specify type annotation in string.
 
 @serde
+@dataclass
 class Bar:
     f: float
     b: bool

--- a/docs/features/postponed-evaluation-of-type-annotation.md
+++ b/docs/features/postponed-evaluation-of-type-annotation.md
@@ -5,8 +5,10 @@
 ```python
 from __future__ import annotations
 from serde import serde
+from dataclasses import dataclass
 
 @serde
+@dataclass
 class Foo:
     i: int
     s: str

--- a/docs/features/python3.9-type-hinting.md
+++ b/docs/features/python3.9-type-hinting.md
@@ -4,6 +4,7 @@ For python >= 3.9, you can use [PEP585](https://www.python.org/dev/peps/pep-0585
 
 ```python
 @serde
+@dataclass
 class Foo:
     i: int
     l: list[str]

--- a/docs/features/rename.md
+++ b/docs/features/rename.md
@@ -4,6 +4,7 @@ In case you want to use a keyword as field such as `class`, you can use `serde_r
 
 ```python
 @serde
+@dataclass
 class Foo:
     class_name: str = field(metadata={'serde_rename': 'class'})
 

--- a/docs/features/skip.md
+++ b/docs/features/skip.md
@@ -4,6 +4,7 @@ You can skip serialization for a certain field, you can use `serde_skip`.
 
 ```python
 @serde
+@dataclass
 class Resource:
     name: str
     hash: str

--- a/docs/features/union-operator.md
+++ b/docs/features/union-operator.md
@@ -3,21 +3,25 @@
 For python >= 3.10, you can use [PEP604](https://www.python.org/dev/peps/pep-0604/) Union operator `X | Y`.
 
 ```python
+from dataclasses import dataclass
 from serde import serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     v: int
 
 
 @serde
+@dataclass
 class Baz:
     v: float
 
 
 @serde
+@dataclass
 class Foo:
     a: int | str
     b: dict[str, int] | list[int]

--- a/docs/features/union.md
+++ b/docs/features/union.md
@@ -8,14 +8,17 @@ This is the default Union representation for pyserde<0.7. Given these dataclasse
 
 ```python
 @serde
+@dataclass
 class Bar:
     b: int
 
 @serde
+@dataclass
 class Baz:
     b: int
 
 @serde(tagging=Untagged)
+@dataclass
 class Foo:
     a: Union[Bar, Baz]
 ```
@@ -28,6 +31,7 @@ This is the default Union representation since 0.7. A class declaration with `Ex
 
 ```
 @serde(tagging=ExternalTagging)
+@dataclass
 class Foo:
     a: Union[Bar, Baz]
 ```
@@ -36,6 +40,7 @@ class Foo:
 >
 > ```python
 > @serde(tagging=ExternalTagging)
+> @dataclass
 > class Foo:
 >    a: Union[List[int], Set[int]]
 > ```
@@ -46,6 +51,7 @@ A class declaration with `InternalTagging` looks like below. If you serialize `F
 
 ```python
 @serde(tagging=InternalTagging("type"))
+@dataclass
 class Foo:
     a: Union[Bar, Baz]
 ```
@@ -56,6 +62,7 @@ A class declaration with `AdjacentTagging` looks like below. If you serialize `F
 
 ```python
 @serde(tagging=AdjacentTagging("type", "content"))
+@dataclass
 class Foo:
     a: Union[Bar, Baz]
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,12 +18,14 @@ Or all at once:
 pip install "pyserde[all]"
 ```
 
-Define your class with pyserde's `@serialize` and `@deserialize` decorators. Be careful that module name is `serde`, not `pyserde`. `pyserde` depends on `dataclasses` module. If you are new to dataclass, I would recommend to read [dataclasses documentation](https://docs.python.org/3/library/dataclasses.html) first.
+Define your class with pyserde's `@serde` decorators. Be careful that module name is `serde`, not `pyserde`. `pyserde` depends on `dataclasses` module. If you are new to dataclass, I would recommend to read [dataclasses documentation](https://docs.python.org/3/library/dataclasses.html) first.
 
 ```python
+from dataclasses import dataclass
 from serde import serde
 
 @serde
+@dataclass
 class Foo:
     i: int
     s: str
@@ -37,9 +39,11 @@ pyserde generates methods necessary for (de)serialization by `@serde` when a cla
 >
 > e.g. If you don't need deserialization functionality, you can add `@serialize` decorator only. But, calling deserialize API e.g. `from_json` for `Foo` will raise an error.
 > ```python
+> from dataclasses import dataclass
 > from serde import serialize
 >
 > @serialize
+> @dataclass
 > class Foo:
 >     i: int
 >     s: str

--- a/docs/supported-data-formats.md
+++ b/docs/supported-data-formats.md
@@ -5,6 +5,7 @@ Currently `dict, `tuple`, `JSON`, `Yaml`, `Toml` and `MsgPack` are supported.
 ```python
 
 @serde
+@dataclass
 class Foo:
     i: int
     s: str

--- a/docs/supported-types.md
+++ b/docs/supported-types.md
@@ -19,10 +19,12 @@
 You can write pretty complex class like this:
 ```python
 @serde
+@dataclass
 class bar:
     i: int
 
 @serde
+@dataclass
 class Foo:
     i: int
     l: List[str]

--- a/examples/any.py
+++ b/examples/any.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 from serde import serde
@@ -5,11 +6,13 @@ from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     v: float
 
 
 @serde
+@dataclass
 class Foo:
     a: Any
     b: Any

--- a/examples/collection.py
+++ b/examples/collection.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from serde import serde
@@ -8,6 +9,7 @@ PY39 = sys.version_info[:3] >= (3, 9, 0)
 
 
 @serde
+@dataclass
 class Foo:
     l: List[str]
     t: Tuple[str, bool]
@@ -19,6 +21,7 @@ class Foo:
 if PY39:
 
     @serde
+    @dataclass
     class FooPy39:
         l: list[str]
         t: tuple[str, bool]

--- a/examples/custom_class_serializer.py
+++ b/examples/custom_class_serializer.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 
 from serde import SerdeSkip, default_deserializer, default_serializer, field, serde
@@ -28,6 +29,7 @@ def deserializer(cls, o):
 
 
 @serde(serializer=serializer, deserializer=deserializer)
+@dataclass
 class Foo:
     i: int
     dt1: datetime

--- a/examples/custom_field_serializer.py
+++ b/examples/custom_field_serializer.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 
 from serde import field, serde
@@ -5,6 +6,7 @@ from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Foo:
     dt1: datetime
     dt2: datetime = field(

--- a/examples/default.py
+++ b/examples/default.py
@@ -1,6 +1,7 @@
+from dataclasses import field
 from typing import Dict
 
-from serde import field, serde
+from serde import serde
 from serde.json import from_json, to_json
 
 

--- a/examples/enum34.py
+++ b/examples/enum34.py
@@ -1,4 +1,5 @@
 import enum
+from dataclasses import dataclass
 
 import imported
 
@@ -24,6 +25,7 @@ class IE(enum.IntEnum):
 
 
 @serde
+@dataclass
 class Foo:
     v0: IE
     v1: IE = IE.V1  # Default enum value.

--- a/examples/flatten.py
+++ b/examples/flatten.py
@@ -1,14 +1,18 @@
+from dataclasses import dataclass
+
 from serde import field, serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     c: float
     d: bool
 
 
 @serde
+@dataclass
 class Foo:
     a: int
     b: str

--- a/examples/forward_reference.py
+++ b/examples/forward_reference.py
@@ -1,7 +1,10 @@
+from dataclasses import dataclass
+
 from serde import serde
 from serde.json import from_json, to_json
 
 
+@dataclass
 class Foo:
     i: int
     s: str
@@ -9,6 +12,7 @@ class Foo:
 
 
 @serde
+@dataclass
 class Bar:
     f: float
     b: bool

--- a/examples/generics.py
+++ b/examples/generics.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Generic, TypeVar
 
 from serde import from_dict, serde, to_dict
@@ -6,16 +7,19 @@ T = TypeVar('T')
 
 
 @serde
+@dataclass
 class Bar:
     n: int
 
 
 @serde
+@dataclass
 class Foo(Generic[T]):
     inner: T
 
 
 @serde
+@dataclass
 class Baz(Generic[T]):
     foo: Foo[T]
 

--- a/examples/jsonfile.py
+++ b/examples/jsonfile.py
@@ -7,6 +7,7 @@ Usage:
     $ poetry install
     $ poetry run python jsonfile.py
 """
+from dataclasses import dataclass
 from typing import List, Optional
 
 import requests
@@ -16,6 +17,7 @@ from serde.json import from_json
 
 
 @serde
+@dataclass
 class Slide:
     title: str
     type: str
@@ -23,6 +25,7 @@ class Slide:
 
 
 @serde
+@dataclass
 class Slideshow:
     author: str
     date: str
@@ -31,6 +34,7 @@ class Slideshow:
 
 
 @serde
+@dataclass
 class Data:
     slideshow: Slideshow
 

--- a/examples/lazy_type_evaluation.py
+++ b/examples/lazy_type_evaluation.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from serde import serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Foo:
     i: int
     s: str

--- a/examples/newtype.py
+++ b/examples/newtype.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import NewType
 
 from serde import serde
@@ -7,6 +8,7 @@ UserId = NewType("UserId", int)
 
 
 @serde
+@dataclass
 class Foo:
     id: UserId
 

--- a/examples/rename.py
+++ b/examples/rename.py
@@ -7,11 +7,14 @@ Usage:
     $ poetry run python rename.py
 """
 
+from dataclasses import dataclass
+
 from serde import field, serde
 from serde.json import to_json
 
 
 @serde
+@dataclass
 class Foo:
     # Use 'class_name' because 'class' is a keyword.
     class_name: str = field(rename='class')

--- a/examples/rename_all.py
+++ b/examples/rename_all.py
@@ -6,6 +6,7 @@ Usage:
     $ poetry install
     $ poetry run python rename_all.py
 """
+from dataclasses import dataclass
 from typing import Optional
 
 from serde import serde
@@ -13,6 +14,7 @@ from serde.json import from_json, to_json
 
 
 @serde(rename_all='pascalcase')
+@dataclass
 class Foo:
     name: str
     no: Optional[int] = None

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,8 +1,11 @@
+from dataclasses import dataclass
+
 from serde import serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Foo:
     i: int
     s: str

--- a/examples/skip.py
+++ b/examples/skip.py
@@ -8,6 +8,7 @@ Usage:
     $ poetry run python skip.py
 """
 
+from dataclasses import dataclass
 from typing import Dict, List
 
 from serde import field, serde
@@ -15,6 +16,7 @@ from serde.json import to_json
 
 
 @serde
+@dataclass
 class Resource:
     name: str
     hash: str
@@ -22,6 +24,7 @@ class Resource:
 
 
 @serde
+@dataclass
 class World:
     player: str
     enemies: List[str] = field(default_factory=list, skip_if_false=True)

--- a/examples/tomlfile.py
+++ b/examples/tomlfile.py
@@ -7,6 +7,7 @@ Usage:
     $ poetry install
     $ poetry run python tomlfile.py
 """
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 from serde import Untagged, serde
@@ -14,6 +15,7 @@ from serde.toml import from_toml
 
 
 @serde
+@dataclass
 class Source:
     url: str
     verify_ssl: bool
@@ -21,11 +23,13 @@ class Source:
 
 
 @serde
+@dataclass
 class Requires:
     python_version: str
 
 
 @serde
+@dataclass
 class Package:
     path: Optional[str] = None
     version: Optional[str] = None
@@ -33,6 +37,7 @@ class Package:
 
 
 @serde(tagging=Untagged)
+@dataclass
 class Pipfile:
     source: List[Source]
     requires: Optional[Requires]

--- a/examples/type_datetime.py
+++ b/examples/type_datetime.py
@@ -1,10 +1,12 @@
 import datetime
+from dataclasses import dataclass
 
 from serde import serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Foo:
     d: datetime.date
     t: datetime.time

--- a/examples/type_decimal.py
+++ b/examples/type_decimal.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from decimal import Decimal
 
 from serde import serde
@@ -5,6 +6,7 @@ from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Foo:
     v: Decimal
 

--- a/examples/union.py
+++ b/examples/union.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Dict, List, Union
 
 from serde import serde
@@ -5,16 +6,19 @@ from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     v: int
 
 
 @serde
+@dataclass
 class Baz:
     v: float
 
 
 @serde
+@dataclass
 class Foo:
     a: Union[int, str]
     b: Union[Dict[str, int], List[int]]

--- a/examples/union_operator.py
+++ b/examples/union_operator.py
@@ -1,18 +1,23 @@
+from dataclasses import dataclass
+
 from serde import serde
 from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     v: int
 
 
 @serde
+@dataclass
 class Baz:
     v: float
 
 
 @serde
+@dataclass
 class Foo:
     a: int | str
     b: dict[str, int] | list[int]

--- a/examples/union_tagging.py
+++ b/examples/union_tagging.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Union
 
 from serde import AdjacentTagging, InternalTagging, Untagged, serde
@@ -5,17 +6,20 @@ from serde.json import from_json, to_json
 
 
 @serde
+@dataclass
 class Bar:
     b: int
 
 
 @serde
+@dataclass
 class Baz:
     b: int
 
 
 def external_tagging():
     @serde
+    @dataclass
     class Foo:
         a: Union[Bar, Baz]
 
@@ -28,6 +32,7 @@ def external_tagging():
 
 def internal_tagging():
     @serde(tagging=InternalTagging("type"))
+    @dataclass
     class Foo:
         a: Union[Bar, Baz]
 
@@ -40,6 +45,7 @@ def internal_tagging():
 
 def adjacent_tagging():
     @serde(tagging=AdjacentTagging(tag="type", content="content"))
+    @dataclass
     class Foo:
         a: Union[Bar, Baz]
 
@@ -52,6 +58,7 @@ def adjacent_tagging():
 
 def untagged():
     @serde(tagging=Untagged)
+    @dataclass
     class Foo:
         a: Union[Bar, Baz]
 

--- a/examples/yamlfile.py
+++ b/examples/yamlfile.py
@@ -7,6 +7,7 @@ Usage:
     $ poetry install
     $ poetry run python yamlfile.py
 """
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 from serde import Untagged, serde
@@ -14,6 +15,7 @@ from serde.yaml import from_yaml
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Info:
     title: str
     description: str
@@ -21,6 +23,7 @@ class Info:
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Parameter:
     name: str
     # not yet supported.
@@ -30,11 +33,13 @@ class Parameter:
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Response:
     description: str
 
 
 @serde(rename_all='camelcase', tagging=Untagged)
+@dataclass
 class Path:
     description: str
     operation_id: str
@@ -43,18 +48,21 @@ class Path:
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Prop:
     type: str
     format: Optional[str]
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Definition:
     required: Optional[List[str]]
     properties: Dict[str, Prop]
 
 
 @serde(rename_all='camelcase')
+@dataclass
 class Swagger:
     swagger: int
     info: Info

--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -9,6 +9,7 @@ Declare a class with pyserde's `@serialize` and `@deserialize` decorators.
 >>> from serde import serde
 >>>
 >>> @serde
+... @dataclass
 ... class Foo:
 ...     i: int
 ...     s: str
@@ -41,10 +42,19 @@ The following modules provides functionalities for supported data formats.
 * `serde.toml`: Serialize and Deserialize in TOML.
 """
 
-import dataclasses
+from dataclasses import dataclass
 
 from .compat import SerdeError, SerdeSkip
-from .core import AdjacentTagging, ExternalTagging, InternalTagging, Untagged, field, init, logger
+from .core import (
+    AdjacentTagging,
+    ExternalTagging,
+    InternalTagging,
+    Untagged,
+    field,
+    init,
+    logger,
+    should_impl_dataclass,
+)
 from .de import default_deserializer, deserialize, from_dict, from_tuple, is_deserializable
 from .se import asdict, astuple, default_serializer, is_serializable, serialize, to_dict, to_tuple
 
@@ -75,8 +85,13 @@ __all__ = (
 
 
 def serde(_cls=None, **kwargs):
+    """
+    serde decorator. Keyword arguments are passed in `serialize` and `deserialize`.
+    """
+
     def wrap(cls):
-        dataclasses.dataclass(cls)
+        if should_impl_dataclass(cls):
+            dataclass(cls)
         serialize(cls, **kwargs)
         deserialize(cls, **kwargs)
         return cls

--- a/serde/core.py
+++ b/serde/core.py
@@ -610,3 +610,40 @@ DefaultTagging = ExternalTagging
 def ensure(expr, description):
     if not expr:
         raise Exception(description)
+
+
+def should_impl_dataclass(cls):
+    """
+    Test if class doesn't have @dataclass.
+
+    `dataclasses.is_dataclass` returns True even Derived class doesn't actually @dataclass.
+    >>> @dataclasses.dataclass
+    ... class Base:
+    ...     a: int
+    >>> class Derived(Base):
+    ...     b: int
+    >>> dataclasses.is_dataclass(Derived)
+    True
+
+    This function tells the class actually have @dataclass or not.
+    >>> should_impl_dataclass(Base)
+    False
+    >>> should_impl_dataclass(Derived)
+    True
+    """
+    if not dataclasses.is_dataclass(cls):
+        return True
+
+    annotations = getattr(cls, "__annotations__", {})
+    if not annotations:
+        return False
+
+    if len(annotations) != len(dataclasses.fields(cls)):
+        return True
+
+    field_names = [field.name for field in dataclass_fields(cls)]
+    for field_name in annotations:
+        if field_name not in field_names:
+            return True
+
+    return False

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -476,12 +476,15 @@ def test_skip_if_default(se, de):
 
 @pytest.mark.parametrize('se,de', format_msgpack)
 def test_inheritance(se, de):
+    from dataclasses import dataclass
+
     @serde.serde
     class Base:
         a: int
         b: str
 
     @serde.serde
+    @dataclass
     class Derived(Base):
         c: float
 
@@ -490,6 +493,22 @@ def test_inheritance(se, de):
 
     derived = Derived(10, "foo", 100.0)
     assert derived == de(Derived, se(derived))
+
+
+@pytest.mark.parametrize('se,de', format_msgpack)
+def test_duplicate_decorators(se, de):
+    from dataclasses import dataclass
+
+    @serde.serde
+    @serde.serde
+    @dataclass
+    @dataclass
+    class Foo:
+        a: int
+        b: str
+
+    foo = Foo(10, "foo")
+    assert foo == de(Foo, se(foo))
 
 
 @pytest.mark.parametrize('se,de', format_msgpack)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, is_dataclass
+
+from serde.core import should_impl_dataclass
+
+
+def test_should_impl_dataclass():
+    @dataclass
+    class Base:
+        a: int
+
+    class Derived(Base):
+        b: int
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert not should_impl_dataclass(Base)
+    assert should_impl_dataclass(Derived)
+
+    @dataclass
+    class Base:
+        pass
+
+    class Derived(Base):
+        pass
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert not should_impl_dataclass(Base)
+    assert not should_impl_dataclass(Derived)
+
+    @dataclass
+    class Base:
+        pass
+
+    class Derived(Base):
+        b: int
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert not should_impl_dataclass(Base)
+    assert should_impl_dataclass(Derived)
+
+    class Base:
+        a: int
+
+    @dataclass
+    class Derived(Base):
+        b: int
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert should_impl_dataclass(Base)
+    assert not should_impl_dataclass(Derived)
+
+    class Base:
+        a: int
+
+    class Derived(Base):
+        b: int
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert should_impl_dataclass(Base)
+    assert should_impl_dataclass(Derived)
+
+    @dataclass
+    class Base1:
+        a: int
+
+    @dataclass
+    class Base2:
+        a: int
+
+    class Derived(Base1, Base2):
+        c: int
+
+    is_dataclass(Base)
+    is_dataclass(Derived)
+    assert not should_impl_dataclass(Base1)
+    assert not should_impl_dataclass(Base2)
+    assert should_impl_dataclass(Derived)


### PR DESCRIPTION
@serde decorator works without @dataclass decorator but there is
no way to prevent mypy from producing type error. Adding @dataclass
decorator back to the all the example code.

Find related mypy page
https://mypy.readthedocs.io/en/stable/additional_features.html#caveats-known-issues

Closes #205 