### PR TITLE
Use str instead of repr in typename, fixing Union[Literal["str"], ...]

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -212,7 +212,7 @@ def typename(typ, with_typing_module: bool = False) -> str:
         args = type_args(typ)
         if not args:
             raise TypeError("Literal type requires at least one literal argument")
-        return f'Literal[{", ".join(repr(e) for e in args)}]'
+        return f'Literal[{", ".join(str(e) for e in args)}]'
     elif typ is Any:
         return f'{mod}Any'
     else:

--- a/serde/core.py
+++ b/serde/core.py
@@ -562,7 +562,7 @@ def union_func_name(prefix: str, union_args: List[Type]) -> str:
     >>> union_func_name("union_se", [int, List[str], IPv4Address])
     'union_se_int_List_str__IPv4Address'
     """
-    return re.sub(r"[ ,\[\]]+", "_", f"{prefix}_{'_'.join([typename(e) for e in union_args])}")
+    return re.sub(r"[^A-Za-z0-9]", "_", f"{prefix}_{'_'.join([typename(e) for e in union_args])}")
 
 
 def literal_func_name(literal_args: List[Any]) -> str:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,14 +3,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Generic, List, NewType, Optional, Set, Tuple, TypeVar, Union
 
-if sys.version_info[:2] == (3, 7):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
-
-
 import serde
 from serde.compat import (
+    Literal,
     is_dict,
     is_generic,
     is_list,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,6 +3,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Generic, List, NewType, Optional, Set, Tuple, TypeVar, Union
 
+if sys.version_info[:2] == (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
+
 import serde
 from serde.compat import (
     is_dict,
@@ -84,6 +90,7 @@ def test_typename():
     assert typename(Dict[str, Foo]) == "Dict[str, Foo]"
     assert typename(Set) == "Set"
     assert typename(Set[int]) == "Set[int]"
+    assert typename(Literal[1, 1.0, "Hey"]) == "Literal[1, 1.0, Hey]"
 
 
 def test_iter_types():

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from dataclasses import dataclass
 from ipaddress import IPv4Address
-from typing import Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
 from uuid import UUID
 
 import pytest
@@ -10,6 +10,7 @@ import pytest
 from serde import SerdeError, from_dict, from_tuple
 from serde import init as serde_init
 from serde import logger, serde, to_dict, to_tuple
+from serde.compat import Literal
 from serde.json import from_json, to_json
 
 logging.basicConfig(level=logging.WARNING)

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -68,7 +68,7 @@ class LitUnion:
     Union of literals
     """
 
-    v: Union[int, Literal["foo", "bar"]]
+    v: Union[int, Literal["foo", "bar", "*"]]
 
 
 def test_union():
@@ -151,6 +151,11 @@ def test_union_with_literal():
 
     v = LitUnion("bar")
     s = '{"v":"bar"}'
+    assert s == to_json(v)
+    assert v == from_json(LitUnion, s)
+
+    v = LitUnion("*")
+    s = '{"v":"*"}'
     assert s == to_json(v)
     assert v == from_json(LitUnion, s)
 


### PR DESCRIPTION
Hi, thank you for this package 😃 

- `str` is more similar to the behavior of format, which is used elsewhere in the function
-  this fixes `Union[something, Literal["str]]`
  - the current implementation tries to use something like `def union_de_something_literal_'str'` as a function name, which contains `'` and thus is invalid