### PR TITLE
Support NumPy 1.23 in Python 3.7/3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ tomli = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional
 tomli-w = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional = true }
 pyyaml = { version = "*", markers = "extra == 'yaml' or extra == 'all'", optional = true }
 numpy = [
-    { version = "~1.21.0,<1.23.0", markers = "python_version ~= '3.7.0' and (extra == 'numpy' or extra == 'all')", optional = true },
-    { version = ">1.21.0,<1.23.0", markers = "python_version ~= '3.8.0' and (extra == 'numpy' or extra == 'all')", optional = true },
+    { version = "~1.21.0", markers = "python_version ~= '3.7.0' and (extra == 'numpy' or extra == 'all')", optional = true },
+    { version = ">1.21.0", markers = "python_version ~= '3.8.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -36,8 +36,8 @@ try:
         # This should work since the only GenericAliases that current NumPy (1.23)
         # exposes are 'NDArray' and '_DType'.
         # Note: these functions are only needed on Python 3.8 or earlier.
-        # On Python >= 3.9, numpy.ndarray[...] and numpy.dtype[...] are used as
-        # typing.GenericAlias.
+        # On Python >= 3.9, numpy.ndarray[...] and numpy.dtype[...] are instances of
+        # the builtin genericalias class.
         def get_np_origin(tp):
             if __is_nptype(tp):
                 return tp.__origin__

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -27,19 +27,28 @@ else:
 
 try:
     if sys.version_info[:2] <= (3, 8):
-        import numpy.typing as npt
+        import numpy as np
 
-        # Note: these functions are only needed on Python 3.8 or earlier
+        def __is_nptype(tp):
+            return getattr(tp, "__origin__", None) in (np.ndarray, np.dtype)
+
+        # If the given type is NDArray or _DType, returns __origin__ or __args__.
+        # This should work since the only GenericAliases that current NumPy (1.23)
+        # exposes are 'NDArray' and '_DType'.
+        # Note: these functions are only needed on Python 3.8 or earlier.
+        # On Python >= 3.9, numpy.ndarray[...] and numpy.dtype[...] are used as
+        # typing.GenericAlias.
         def get_np_origin(tp):
-            if isinstance(tp, npt._generic_alias._GenericAlias) and tp.__origin__ is not ClassVar:
+            if __is_nptype(tp):
                 return tp.__origin__
-            return None
+            else:
+                return None
 
         def get_np_args(tp):
-            if isinstance(tp, npt._generic_alias._GenericAlias) and tp.__origin__ is not ClassVar:
+            if __is_nptype(tp):
                 return tp.__args__
-
-            return ()
+            else:
+                return ()
 
     else:
 


### PR DESCRIPTION
Fix #246 

I didn't test it locally since I only have Python 3.10..., but let's see what happens 😅 