### PR TITLE
chore: Bump allowed version of numpy to >1.21.0 on Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ tomli = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional
 tomli-w = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional = true }
 pyyaml = { version = "*", markers = "extra == 'yaml' or extra == 'all'", optional = true }
 numpy = [
-    { version = "~1.21.0", markers = "python_version ~= '3.7.0' and (extra == 'numpy' or extra == 'all')", optional = true },
+    { version = ">1.21.0", markers = "python_version ~= '3.7.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.21.0", markers = "python_version ~= '3.8.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
@@ -46,7 +46,7 @@ tomli = "*"
 tomli-w = "*"
 msgpack = "*"
 numpy = [
-    { version = "~1.21.0", markers = "python_version ~= '3.7.0'" },
+    { version = ">1.21.0", markers = "python_version ~= '3.7.0'" },
     { version = ">1.21.0", markers = "python_version ~= '3.8.0'" },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0'" },
     { version = ">1.22.0", markers = "python_version ~= '3.10'" },


### PR DESCRIPTION
In fact, only numpy <v1.22.0 can (and will) be installed on Python 3.7.  However,
because of a (possible) bug in poetry, pyserde can't be installed in
a project which requires numpy >=v1.22.0 because it thinks that pyserde
requires v1.21.x (even on versions of Python >3.7).

Loosening this bound still allows numpy 1.21.x to be installed in python 3.7, and
also allows pyserde to be installed when numpy >=1.22.0 is required.