### PR TITLE
feat: pep681

### DIFF
--- a/docs/features/decorators.md
+++ b/docs/features/decorators.md
@@ -36,12 +36,13 @@ class Foo:
 > **Note:** `@serde` actually works without @dataclass decorator, because it detects and add @dataclass to the declared class automatically. However, mypy will produce `Too many arguments` or `Unexpected keyword argument` error. This is due to the current mypy limitation. See the following documentation for more information.
 https://mypy.readthedocs.io/en/stable/additional_features.html#caveats-known-issues
 >
->
 > ```python
 > @serde
 > class Foo:
 >     ...
 > ```
+>
+> But if you're a PEP681 compliant type checker (e.g. pyright) user, you don't get the type error because pyserde supports [PEP681 dataclass_transform](https://peps.python.org/pep-0681/)
 
 
 ## `@serialize`/`@deserialize`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,4 +77,3 @@ print(from_json(Foo, s))
 ```
 
 That's it! pyserde offers many more features. If you're interested, please read the rest of the documentation.
-

--- a/examples/pep681.py
+++ b/examples/pep681.py
@@ -1,0 +1,25 @@
+from serde import serde
+from serde.json import from_json, to_json
+
+
+# Thanks to PEP681 @dataclass_transform, @dataclass decorator is no longer mandatory
+# if you use PEP681 supported type check such as pyright. If you are a mypy user,
+# you still need @dataclass decorator.
+@serde
+class Foo:
+    i: int
+    s: str
+    f: float
+    b: bool
+
+
+def main():
+    f = Foo(i=10, s='foo', f=100.0, b=True)
+    print(f"Into Json: {to_json(f)}")
+
+    s = '{"i": 10, "s": "foo", "f": 100.0, "b": true}'
+    print(f"From Json: {from_json(Foo, s)}")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -13,6 +13,7 @@ import jsonfile
 import lazy_type_evaluation
 import literal
 import newtype
+import pep681
 import rename
 import rename_all
 import simple
@@ -57,6 +58,7 @@ def run_all():
     run(type_check_strict)
     run(type_check_coerce)
     run(user_exception)
+    run(pep681)
     if PY310:
         import union_operator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = "^3.7.0"
 typing_inspect = ">=0.4.0"
-typing_extensions = { version = "*", markers = "python_version ~= '3.7.0'" }
+typing_extensions = { version = ">=4.1.0", markers = "python_version ~= '3.7.0'" }
 casefy = "*"
 jinja2 = "*"
 msgpack = { version = "*", markers = "extra == 'msgpack' or extra == 'all'", optional = true }

--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -49,6 +49,8 @@ Other modules
 from dataclasses import dataclass
 from typing import Callable, Optional, Type, overload
 
+from typing_extensions import dataclass_transform
+
 from .compat import SerdeError, SerdeSkip, T
 from .core import (
     AdjacentTagging,
@@ -126,6 +128,7 @@ def serde(
     ...
 
 
+@dataclass_transform()
 def serde(
     _cls=None,
     **kwargs,

--- a/serde/de.py
+++ b/serde/de.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, is_dataclass
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import jinja2
-from typing_extensions import Type
+from typing_extensions import Type, dataclass_transform
 
 from .compat import (
     Literal,
@@ -132,6 +132,7 @@ def _make_deserialize(
     return C
 
 
+@dataclass_transform()
 def deserialize(
     _cls=None,
     rename_all: Optional[str] = None,

--- a/serde/se.py
+++ b/serde/se.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, is_dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar
 
 import jinja2
-from typing_extensions import Type
+from typing_extensions import Type, dataclass_transform
 
 from .compat import (
     Literal,
@@ -132,6 +132,7 @@ def _make_serialize(
     return C
 
 
+@dataclass_transform()
 def serialize(
     _cls=None,
     rename_all: Optional[str] = None,


### PR DESCRIPTION
Thanks to PEP681 @dataclass_transform, @dataclass decorator is no longer mandatory if you use PEP681 supported type check such as pyright. If you are a mypy user, you still need @dataclass decorator.

```
@serde
#@dataclass <== No longer needed.
class Foo:
    i: int
```

Closes #267 