### PR TITLE
Add support for optional unions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ numpy = [
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]
 orjson = { version = "*", markers = "extra == 'orjson' or extra == 'all'", optional = true }
-typing-utils = { version = "*", markers = "python_version < '3.8'" }
 
 [tool.poetry.dev-dependencies]
 pyyaml = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ numpy = [
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]
 orjson = { version = "*", markers = "extra == 'orjson' or extra == 'all'", optional = true }
+typing-utils = { version = "*", markers = "python_version < '3.8'" }
 
 [tool.poetry.dev-dependencies]
 pyyaml = "*"

--- a/serde/de.py
+++ b/serde/de.py
@@ -9,7 +9,7 @@ import dataclasses
 import functools
 import typing
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Optional, TypeVar, get_args
 
 import jinja2
 from typing_extensions import Type, dataclass_transform
@@ -515,6 +515,8 @@ class DeField(Field):
     def data(self) -> str:
         if self.iterbased:
             return f'{self.datavar}[{self.index}]'
+        elif is_union(self.type) and type(None) in get_args(self.type):
+            return f'{self.datavar}.get("{self.conv_name()}")'
         else:
             return f'{self.datavar}["{self.conv_name()}"]'
 

--- a/serde/de.py
+++ b/serde/de.py
@@ -12,12 +12,6 @@ import typing
 from dataclasses import dataclass, is_dataclass
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
-if sys.version_info[1] < 8:
-    # get_args was added in python 3.8
-    from typing_utils import get_args
-else:
-    from typing import get_args
-
 import jinja2
 from typing_extensions import Type, dataclass_transform
 
@@ -27,6 +21,7 @@ from .compat import (
     SerdeSkip,
     UserError,
     find_generic_arg,
+    get_args,
     get_generic_arg,
     get_origin,
     has_default,

--- a/serde/de.py
+++ b/serde/de.py
@@ -7,9 +7,16 @@ import abc
 import collections
 import dataclasses
 import functools
+import sys
 import typing
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Callable, Dict, List, Optional, TypeVar, get_args
+from typing import Any, Callable, Dict, List, Optional, TypeVar
+
+if sys.version_info[1] < 8:
+    # get_args was added in python 3.8
+    from typing_utils import get_args
+else:
+    from typing import get_args
 
 import jinja2
 from typing_extensions import Type, dataclass_transform

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -54,6 +54,16 @@ class PriOptUnion:
 
 @serde
 @dataclass(unsafe_hash=True)
+class OptionalUnion:
+    """
+    Union Primitives.
+    """
+
+    v: Optional[Union[int, str]]
+
+
+@serde
+@dataclass(unsafe_hash=True)
 class ContUnion:
     """
     Union Containers.
@@ -119,6 +129,9 @@ def test_union_optional():
     s = '{"v":false}'
     assert s == to_json(v)
     assert v == from_json(PriOptUnion, s)
+
+    assert PriOptUnion(None) == from_json(PriOptUnion, '{}')
+    assert OptionalUnion(None) == from_json(OptionalUnion, '{}')
 
 
 def test_union_containers():


### PR DESCRIPTION
Fixes  #293.

Adds a check for optionals in union types (and optional unions), allowing parsing when the optional field is missing.