### PR TITLE
Generate serialization/deserialization code for dataclasses not marked with @serde

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -213,7 +213,13 @@ def deserialize(
     Foo(i=10, dt=datetime.datetime(2021, 1, 1, 0, 0))
     """
 
+    stack = []
+
     def wrap(cls: Type):
+        if cls in stack:
+            return
+        stack.append(cls)
+
         tagging.check()
 
         # If no `dataclass` found in the class, dataclassify it automatically.
@@ -255,6 +261,10 @@ def deserialize(
 
         # Collect types used in the generated code.
         for typ in iter_types(cls):
+            # When we encounter a dataclass not marked with deserialize, then also generate
+            # deserialize functions for it.
+            if is_dataclass_without_de(typ):
+                wrap(typ)
             if typ is cls or (is_primitive(typ) and not is_enum(typ) and not is_new_type_primitive(typ)):
                 continue
             if is_generic(typ):
@@ -290,6 +300,7 @@ def deserialize(
 
         logger.debug(f'{typename(cls)}: {SERDE_SCOPE} {scope}')
 
+        stack.pop()
         return cls
 
     if _cls is None:
@@ -310,6 +321,15 @@ def is_deserializable(instance_or_class: Any) -> bool:
     True
     """
     return hasattr(instance_or_class, SERDE_SCOPE)
+
+
+def is_dataclass_without_de(cls: Type[Any]) -> bool:
+    if not dataclasses.is_dataclass(cls):
+        return False
+    if not hasattr(cls, SERDE_SCOPE):
+        return True
+    scope: Optional[SerdeScope] = getattr(cls, SERDE_SCOPE)
+    return FROM_DICT not in scope.funcs
 
 
 class Deserializer(metaclass=abc.ABCMeta):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1024,3 +1024,19 @@ def test_class_var() -> None:
     f = Nested()
     assert {"v": {"v": 100}} == serde.to_dict(f)
     assert f == serde.from_dict(Nested, {})
+
+
+def test_nested_dataclass_without_serde() -> None:
+    @dataclasses.dataclass
+    class Foo:
+        v: int
+
+    @serde.serde
+    @dataclasses.dataclass
+    class Wrapper:
+        foo: Foo
+
+    a = Wrapper(foo=Foo(v=1))
+    serialized = serde.to_dict(a)
+    assert {'foo': {'v': 1}} == serialized
+    assert a == serde.from_dict(Wrapper, serialized)


### PR DESCRIPTION
This is an attempt to resolve https://github.com/yukinarit/pyserde/issues/309. It generates serialization/deserialization code for a nested dataclass field if that field type is not marked with `@serde`. Currently, the ser/de code is generated based on the `@serde` configuration of the containing dataclass, which is not ideal, it should probably be generated with an "empty" `@serde` configuration. But for that I'd need to store the type stack (which is used as a recursion guard) outside the `serialize` function as a global variable (?).

Let me know what you think about this approach.

Fixes: https://github.com/yukinarit/pyserde/issues/309