### PR TITLE
Fix deserialization with NewType and Untagged Union

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -38,7 +38,6 @@ from .compat import (
     is_generic,
     is_list,
     is_literal,
-    is_new_type_primitive,
     is_none,
     is_opt,
     is_primitive,
@@ -273,7 +272,7 @@ def deserialize(
                 # We call deserialize and not wrap to make sure that we will use the default serde
                 # configuration for generating the deserialization function.
                 deserialize(typ)
-            if typ is cls or (is_primitive(typ) and not is_enum(typ) and not is_new_type_primitive(typ)):
+            if typ is cls or (is_primitive(typ) and not is_enum(typ)):
                 continue
             if is_generic(typ):
                 g[typename(typ)] = get_origin(typ)
@@ -1006,7 +1005,7 @@ def {{func}}(cls=cls, maybe_generic=None, data=None, reuse_instances = {{serde_s
     fake_dict = {"fake_key": data}
     {% endif %}
 
-    {% if t|is_primitive or t |is_none %}
+    {% if t|is_primitive or t|is_none %}
     if not isinstance(fake_dict["fake_key"], {{t|typename}}):
         raise Exception("Not a type of {{t|typename}}")
     {% endif %}

--- a/serde/se.py
+++ b/serde/se.py
@@ -32,7 +32,6 @@ from .compat import (
     is_generic,
     is_list,
     is_literal,
-    is_new_type_primitive,
     is_none,
     is_opt,
     is_primitive,
@@ -273,7 +272,7 @@ def serialize(
                 # configuration for generating the serialization function.
                 serialize(typ)
 
-            if typ is cls or (is_primitive(typ) and not is_enum(typ) and not is_new_type_primitive(typ)):
+            if typ is cls or (is_primitive(typ) and not is_enum(typ)):
                 continue
             g[typename(typ)] = typ
 


### PR DESCRIPTION
It seems NewType is passed in isinstance function when certain conditions are met. This fix will prevent from adding NewType'd Class inside the scope of generated function.

Closes #292