### PR TITLE
Fix variable length of tuple

### DIFF
--- a/examples/runner.py
+++ b/examples/runner.py
@@ -8,7 +8,6 @@ import custom_class_serializer
 import custom_field_serializer
 import default
 import default_dict
-import ellipsis
 import env
 import flatten
 import forward_reference
@@ -36,6 +35,7 @@ import type_decimal
 import union
 import union_tagging
 import user_exception
+import variable_length_tuple
 import yamlfile
 
 PY310 = sys.version_info[:3] >= (3, 10, 0)
@@ -72,7 +72,7 @@ def run_all():
     run(type_check_coerce)
     run(user_exception)
     run(pep681)
-    run(ellipsis)
+    run(variable_length_tuple)
     run(init_var)
     run(class_var)
     run(alias)

--- a/examples/variable_length_tuple.py
+++ b/examples/variable_length_tuple.py
@@ -12,10 +12,10 @@ class Foo:
 
 
 def main():
-    f = Foo(v=(10, 'foo'))
+    f = Foo(v=(1, 2, 3))
     print(f"Into Json: {to_json(f)}")
 
-    s = '{"v": [10, "foo"]}'
+    s = '{"v": [1, 2, 3]}'
     print(f"From Json: {from_json(Foo, s)}")
 
 

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -241,7 +241,7 @@ def typename(typ: Type[Any], with_typing_module: bool = False) -> str:
         return f'Literal[{", ".join(str(e) for e in args)}]'
     elif typ is Any:
         return f'{mod}Any'
-    elif typ is Ellipsis:
+    elif is_ellipsis(typ):
         return '...'
     else:
         # Get super type for NewType
@@ -569,6 +569,23 @@ def is_bare_tuple(typ: Type[Any]) -> bool:
     return typ in (Tuple, tuple)
 
 
+def is_variable_tuple(typ: Type[Any]) -> bool:
+    """
+    Test if the type is a variable length of tuple `typing.Tuple[T, ...]`.
+
+    >>> from typing import Tuple
+    >>> is_variable_tuple(Tuple[int, ...])
+    True
+    >>> is_variable_tuple(Tuple[int, bool])
+    False
+    >>> is_variable_tuple(Tuple[()])
+    False
+    """
+    istuple = is_tuple(typ) and not is_bare_tuple(typ)
+    args = get_args(typ)
+    return istuple and len(args) == 2 and is_ellipsis(args[1])
+
+
 def is_set(typ: Type[Any]) -> bool:
     """
     Test if the type is `typing.Set` or `typing.FrozenSet`.
@@ -789,6 +806,10 @@ def is_str_serializable_instance(obj: Any) -> bool:
 
 def is_datetime_instance(obj: Any) -> bool:
     return isinstance(obj, DateTimeTypes)
+
+
+def is_ellipsis(typ: Any) -> bool:
+    return typ is Ellipsis
 
 
 def find_generic_arg(cls: Type[Any], field: TypeVar) -> int:

--- a/serde/core.py
+++ b/serde/core.py
@@ -33,6 +33,7 @@ from .compat import (
     is_set,
     is_tuple,
     is_union,
+    is_variable_tuple,
     type_args,
     typename,
 )
@@ -251,6 +252,11 @@ def is_set_instance(obj: Any, typ: Type) -> bool:
 def is_tuple_instance(obj: Any, typ: Type) -> bool:
     if not isinstance(obj, tuple):
         return False
+    if is_variable_tuple(typ):
+        arg = type_args(typ)[0]
+        for v in obj:
+            if not is_instance(v, arg):
+                return False
     if len(obj) == 0 or is_bare_tuple(typ):
         return True
     for i, arg in enumerate(type_args(typ)):

--- a/serde/se.py
+++ b/serde/se.py
@@ -19,6 +19,7 @@ from .compat import (
     SerdeError,
     SerdeSkip,
     get_origin,
+    is_any,
     is_bare_dict,
     is_bare_list,
     is_bare_opt,
@@ -28,6 +29,7 @@ from .compat import (
     is_datetime,
     is_datetime_instance,
     is_dict,
+    is_ellipsis,
     is_enum,
     is_generic,
     is_list,
@@ -40,6 +42,7 @@ from .compat import (
     is_str_serializable_instance,
     is_tuple,
     is_union,
+    is_variable_tuple,
     iter_types,
     iter_unions,
     type_args,
@@ -719,7 +722,7 @@ convert_sets=convert_sets), coerce(int, foo[2]),)"
             res = f"{arg.varname} if reuse_instances else {arg.varname}.isoformat()"
         elif is_none(arg.type):
             res = "None"
-        elif arg.type is Any or arg.type is Ellipsis or isinstance(arg.type, TypeVar):
+        elif is_any(arg.type) or isinstance(arg.type, TypeVar):
             res = f"to_obj({arg.varname}, True, False, False)"
         elif is_generic(arg.type):
             arg.type = get_origin(arg.type)
@@ -801,7 +804,7 @@ convert_sets=convert_sets), coerce(int, foo[2]),)"
         """
         Render rvalue for tuple.
         """
-        if is_bare_tuple(arg.type):
+        if is_bare_tuple(arg.type) or is_variable_tuple(arg.type):
             return arg.varname
         else:
             rvalues = []

--- a/tests/common.py
+++ b/tests/common.py
@@ -80,7 +80,7 @@ types: List = [
     param({1, 2}, FrozenSet[int], toml_not_supported),
     param((1, 1), Tuple[int, int]),
     param((1, 1), Tuple),
-    param((1, 1), Tuple[int, ...]),
+    param((1, 2, 3), Tuple[int, ...]),
     param({'a': 1}, Dict[str, int]),
     param({'a': 1}, Dict),
     param({'a': 1}, dict),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -204,7 +204,10 @@ def test_is_instance():
     assert is_instance((10, "a"), tuple)
     assert is_instance((10, 'foo', 100.0, True), Tuple[int, str, float, bool])
     assert not is_instance((10, 'foo', 100.0, "last-type-is-wrong"), Tuple[int, str, float, bool])
-    assert is_instance((10, "a"), Tuple[int, ...])
+    assert is_instance((10, 20), Tuple[int, ...])
+    assert is_instance((10, 20, 30), Tuple[int, ...])
+    assert is_instance((), Tuple[int, ...])
+    assert not is_instance((10, "a"), Tuple[int, ...])
 
     # Tuple of dataclasses
     assert is_instance((Int(10), Str('foo'), Float(100.0), Bool(True)), Tuple[Int, Str, Float, Bool])


### PR DESCRIPTION
* `Tuple[int]` should accept only a tuple of size 1
* `Tuple[int, bool]` should accept only a tuple of size 2
* `Tuple[int, ...]` should accept empty tuple, tuples of size 1, 2 ... N
* `Tuple[int, bool, ...]` Not allowed
* `Tuple[()]` Not supported


Closes #302