### PR TITLE
fix: Fixed broken strict type checking for Optionals. Fixes #330

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -722,6 +722,7 @@ def {{type_check_func}}(self):
            compat.is_list(f.type) or
            compat.is_dict(f.type) or
            compat.is_tuple(f.type) or
+           compat.is_opt(f.type) or
            compat.is_primitive(f.type) or
            compat.is_str_serializable(f.type) or
            compat.is_datetime(f.type)) %}


### PR DESCRIPTION
Single addition to core that fixes strict type checking for Optional types.
See #330 for example.

All tests pass.