### PR TITLE
Do not render field with init=False

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -436,7 +436,7 @@ class Field:
     name: Optional[str]
     default: Any = field(default_factory=dataclasses._MISSING_TYPE)
     default_factory: Any = field(default_factory=dataclasses._MISSING_TYPE)
-    init: Any = field(default_factory=dataclasses._MISSING_TYPE)
+    init: bool = field(default_factory=dataclasses._MISSING_TYPE)
     repr: Any = field(default_factory=dataclasses._MISSING_TYPE)
     hash: Any = field(default_factory=dataclasses._MISSING_TYPE)
     compare: Any = field(default_factory=dataclasses._MISSING_TYPE)

--- a/tests/common.py
+++ b/tests/common.py
@@ -92,6 +92,7 @@ types: List = [
     param(data.Pri(10, 'foo', 100.0, True), Optional[data.Pri]),
     param(None, Optional[data.Pri], toml_not_supported),
     param(data.Recur(data.Recur(None, None, None), None, None), data.Recur, toml_not_supported),
+    param(data.Init(1), data.Init),
     param(10, NewType('Int', int)),  # NewType
     param({'a': 1}, Any),  # Any
     param(GenericClass[str, int]('foo', 10), GenericClass[str, int]),  # Generic

--- a/tests/data.py
+++ b/tests/data.py
@@ -2,7 +2,7 @@ import enum
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
-from serde import serde
+from serde import field, serde
 
 from . import imported
 
@@ -257,3 +257,13 @@ PRILIST = ([10], ['foo'], [100.0], [True])
 NESTED_PRILIST = ([INT], [STR], [FLOAT], [BOOL])
 
 NESTED_PRILIST_TUPLE = ([(10,)], [('foo',)], [(100.0,)], [(True,)])
+
+
+@dataclass
+@serde
+class Init:
+    a: int
+    b: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.b = self.a * 10


### PR DESCRIPTION
```python
@dataclass
@serde
class Init:
    a: int
    b: int = field(init=False)

    def __post_init__(self) -> None:
        self.b = self.a * 10
```

Field "b" is not rendreed, otherwise class constructor raises this error
```python
Foo.__init__() takes 2 positional arguments but 3 were given
```

Closes #333 