### PR TITLE
Union directly

### DIFF
--- a/examples/runner.py
+++ b/examples/runner.py
@@ -40,6 +40,7 @@ import type_datetime
 import type_decimal
 import union
 import union_tagging
+import union_directly
 import user_exception
 import variable_length_tuple
 import yamlfile
@@ -73,6 +74,7 @@ def run_all() -> None:
     run(type_decimal)
     run(type_datetime)
     run(union_tagging)
+    run(union_directly)
     run(generics)
     run(generics_nested)
     run(nested)

--- a/examples/union_directly.py
+++ b/examples/union_directly.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Union
+
+from serde import serde, Untagged, AdjacentTagging, InternalTagging
+from serde.json import from_json, to_json
+
+
+@serde
+@dataclass
+class Bar:
+    b: int
+
+
+@serde
+@dataclass(unsafe_hash=True)
+class Baz:
+    b: int
+
+
+def main() -> None:
+    baz = Baz(10)
+
+    print("# external tagging (default)")
+    a = to_json(baz, cls=Union[Bar, Baz])
+    print("IntoJSON", a)
+    print("FromJSON", from_json(Union[Bar, Baz], a))
+
+    print("# internal tagging")
+    a = to_json(baz, cls=InternalTagging("type", Union[Bar, Baz]))
+    print("IntoJSON", a)
+    print("FromJSON", from_json(InternalTagging("type", Union[Bar, Baz]), a))
+
+    print("# adjacent tagging")
+    a = to_json(baz, cls=AdjacentTagging("type", "content", Union[Bar, Baz]))
+    print("IntoJSON", a)
+    print("FromJSON", from_json(AdjacentTagging("type", "content", Union[Bar, Baz]), a))
+
+    print("# untagged")
+    a = to_json(baz, cls=Untagged(Union[Bar, Baz]))
+    print("IntoJSON", a)
+    print("FromJSON", from_json(Untagged(Union[Bar, Baz]), a))
+
+
+if __name__ == "__main__":
+    main()

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -114,6 +114,18 @@ DateTimeTypes = (datetime.date, datetime.time, datetime.datetime)
 """ List of datetime types """
 
 
+@dataclasses.dataclass
+class _WithTagging(Generic[T]):
+    """
+    Intermediate data structure for (de)serializaing Union without dataclass.
+    """
+
+    inner: T
+    """ Union type .e.g Union[Foo,Bar] passed in from_obj. """
+    tagging: Any
+    """ Union Tagging """
+
+
 class SerdeError(Exception):
     """
     Serde error class.
@@ -474,6 +486,13 @@ def is_union(typ: Any) -> bool:
     >>> is_union(Union[int, str])
     True
     """
+
+    try:
+        # When `_WithTagging` is received, it will check inner type.
+        if isinstance(typ, _WithTagging):
+            return is_union(typ.inner)
+    except Exception:
+        pass
 
     # Python 3.10 Union operator e.g. str | int
     if sys.version_info[:2] >= (3, 10):

--- a/serde/core.py
+++ b/serde/core.py
@@ -40,7 +40,7 @@ from .compat import (
 from .numpy import is_numpy_available, is_numpy_type
 
 __all__ = [
-    "SerdeScope",
+    "Scope",
     "gen",
     "add_func",
     "Func",
@@ -78,7 +78,7 @@ def init(debug: bool = False) -> None:
 
 
 @dataclass
-class SerdeScope:
+class Scope:
     """
     Container to store types and functions used in code generation context.
     """
@@ -174,12 +174,12 @@ def gen(
 
 
 def add_func(
-    serde_scope: SerdeScope, func_name: str, func_code: str, globals: Dict[str, Any]
+    serde_scope: Scope, func_name: str, func_code: str, globals: Dict[str, Any]
 ) -> None:
     """
-    Generate a function and add it to a SerdeScope's `funcs` dictionary.
+    Generate a function and add it to a Scope's `funcs` dictionary.
 
-    * `serde_scope`: the SerdeScope instance to modify
+    * `serde_scope`: the Scope instance to modify
     * `func_name`: the name of the function
     * `func_code`: the source code of the function
     * `globals`: global variables that should be accessible to the generated function
@@ -198,7 +198,7 @@ def is_instance(obj: Any, typ: Type[Any]) -> bool:
     Subscripted Generics e.g. `List[int]`.
     """
     if dataclasses.is_dataclass(typ):
-        serde_scope: Optional[SerdeScope] = getattr(typ, SERDE_SCOPE, None)
+        serde_scope: Optional[Scope] = getattr(typ, SERDE_SCOPE, None)
         if serde_scope:
             try:
                 serde_scope.funcs[TYPE_CHECK](obj)

--- a/serde/de.py
+++ b/serde/de.py
@@ -64,7 +64,7 @@ from .core import (
     DefaultTagging,
     Field,
     NoCheck,
-    SerdeScope,
+    Scope,
     Tagging,
     TypeCheck,
     add_func,
@@ -214,9 +214,9 @@ def deserialize(
         # Create a scope storage used by serde.
         # Each class should get own scope. Child classes can not share scope with parent class.
         # That's why we need the "scope.cls is not cls" check.
-        scope: Optional[SerdeScope] = getattr(cls, SERDE_SCOPE, None)
+        scope: Optional[Scope] = getattr(cls, SERDE_SCOPE, None)
         if scope is None or scope.cls is not cls:
-            scope = SerdeScope(cls, reuse_instances_default=reuse_instances_default)
+            scope = Scope(cls, reuse_instances_default=reuse_instances_default)
             setattr(cls, SERDE_SCOPE, scope)
 
         # Set some globals for all generated functions
@@ -331,7 +331,7 @@ def is_dataclass_without_de(cls: Type[Any]) -> bool:
         return False
     if not hasattr(cls, SERDE_SCOPE):
         return True
-    scope: Optional[SerdeScope] = getattr(cls, SERDE_SCOPE)
+    scope: Optional[Scope] = getattr(cls, SERDE_SCOPE)
     return FROM_DICT not in scope.funcs
 
 
@@ -362,7 +362,7 @@ def from_obj(c: Type[T], o: Any, named: bool, reuse_instances: bool) -> T:
     """
 
     def deserializable_to_obj(cls):
-        serde_scope: SerdeScope = getattr(cls, SERDE_SCOPE)
+        serde_scope: Scope = getattr(cls, SERDE_SCOPE)
         func_name = FROM_DICT if named else FROM_ITER
         res = serde_scope.funcs[func_name](
             cls, maybe_generic=maybe_generic, data=o, reuse_instances=reuse_instances

--- a/serde/inspect.py
+++ b/serde/inspect.py
@@ -20,7 +20,7 @@ import sys
 from typing import Any
 from typing_extensions import Type
 
-from .core import SERDE_SCOPE, Scope, init, logger
+from .core import SERDE_SCOPE, init, logger
 
 init(True)
 

--- a/serde/inspect.py
+++ b/serde/inspect.py
@@ -20,7 +20,7 @@ import sys
 from typing import Any
 from typing_extensions import Type
 
-from .core import SERDE_SCOPE, init, logger
+from .core import SERDE_SCOPE, Scope, init, logger
 
 init(True)
 

--- a/serde/json.py
+++ b/serde/json.py
@@ -1,7 +1,7 @@
 """
 Serialize and Deserialize in JSON format.
 """
-from typing import Any, overload
+from typing import Any, overload, Optional
 
 from typing_extensions import Type
 
@@ -51,7 +51,9 @@ class JsonDeserializer(Deserializer[str]):
         return json_loads(data, **opts)
 
 
-def to_json(obj: Any, se: Type[Serializer[str]] = JsonSerializer, **opts: Any) -> str:
+def to_json(
+    obj: Any, cls: Optional[Any] = None, se: Type[Serializer[str]] = JsonSerializer, **opts: Any
+) -> str:
     """
     Serialize the object into JSON str. [orjson](https://github.com/ijl/orjson)
     will be used if installed.
@@ -65,7 +67,7 @@ def to_json(obj: Any, se: Type[Serializer[str]] = JsonSerializer, **opts: Any) -
     If you want to use another json package, you can subclass `JsonSerializer` and implement
     your own logic.
     """
-    return se.serialize(to_dict(obj, reuse_instances=False, convert_sets=True), **opts)
+    return se.serialize(to_dict(obj, c=cls, reuse_instances=False, convert_sets=True), **opts)
 
 
 @overload

--- a/serde/msgpack.py
+++ b/serde/msgpack.py
@@ -40,6 +40,7 @@ class MsgPackDeserializer(Deserializer[bytes]):
 
 def to_msgpack(
     obj: Any,
+    cls: Optional[Any] = None,
     se: Type[Serializer[bytes]] = MsgPackSerializer,
     named: bool = True,
     ext_dict: Optional[Dict[Type[Any], int]] = None,
@@ -66,9 +67,10 @@ def to_msgpack(
         if ext_type_code is None:
             raise SerdeError(f"Could not find type code for {obj_type.__name__} in ext_dict")
 
-    to_func = to_dict if named else to_tuple
+    kwargs: Any = {"c": cls, "reuse_instances": False, "convert_sets": True}
+    dict_or_tuple = to_dict(obj, **kwargs) if named else to_tuple(obj, **kwargs)
     return se.serialize(
-        to_func(obj, reuse_instances=False, convert_sets=True),
+        dict_or_tuple,
         ext_type_code=ext_type_code,
         **opts,
     )

--- a/serde/pickle.py
+++ b/serde/pickle.py
@@ -2,7 +2,7 @@
 Serialize and Deserialize in Pickle format.
 """
 import pickle
-from typing import Type, Any, overload
+from typing import Type, Any, overload, Optional
 
 from .compat import T
 from .de import Deserializer, from_dict
@@ -23,8 +23,10 @@ class PickleDeserializer(Deserializer[bytes]):
         return pickle.loads(data, **opts)
 
 
-def to_pickle(obj: Any, se: Type[Serializer[bytes]] = PickleSerializer, **opts: Any) -> bytes:
-    return se.serialize(to_dict(obj, reuse_instances=False), **opts)
+def to_pickle(
+    obj: Any, cls: Optional[Any] = None, se: Type[Serializer[bytes]] = PickleSerializer, **opts: Any
+) -> bytes:
+    return se.serialize(to_dict(obj, c=cls, reuse_instances=False), **opts)
 
 
 @overload

--- a/serde/se.py
+++ b/serde/se.py
@@ -58,7 +58,7 @@ from .core import (
     DefaultTagging,
     Field,
     NoCheck,
-    SerdeScope,
+    Scope,
     Tagging,
     TypeCheck,
     add_func,
@@ -195,9 +195,9 @@ def serialize(
         # Create a scope storage used by serde.
         # Each class should get own scope. Child classes can not share scope with parent class.
         # That's why we need the "scope.cls is not cls" check.
-        scope: Optional[SerdeScope] = getattr(cls, SERDE_SCOPE, None)
+        scope: Optional[Scope] = getattr(cls, SERDE_SCOPE, None)
         if scope is None or scope.cls is not cls:
-            scope = SerdeScope(
+            scope = Scope(
                 cls,
                 reuse_instances_default=reuse_instances_default,
                 convert_sets_default=convert_sets_default,
@@ -303,7 +303,7 @@ def is_dataclass_without_se(cls: Type[Any]) -> bool:
         return False
     if not hasattr(cls, SERDE_SCOPE):
         return True
-    scope: Optional[SerdeScope] = getattr(cls, SERDE_SCOPE)
+    scope: Optional[Scope] = getattr(cls, SERDE_SCOPE)
     return TO_DICT not in scope.funcs
 
 
@@ -311,7 +311,7 @@ def to_obj(
     o, named: bool, reuse_instances: bool, convert_sets: bool, c: Optional[Type[Any]] = None
 ):
     def serializable_to_obj(object):
-        serde_scope: SerdeScope = getattr(object, SERDE_SCOPE)
+        serde_scope: Scope = getattr(object, SERDE_SCOPE)
         func_name = TO_DICT if named else TO_ITER
         return serde_scope.funcs[func_name](
             object, reuse_instances=reuse_instances, convert_sets=convert_sets

--- a/serde/se.py
+++ b/serde/se.py
@@ -50,6 +50,7 @@ from .compat import (
     typename,
 )
 from .core import (
+    CACHE,
     SERDE_SCOPE,
     TO_DICT,
     TO_ITER,
@@ -307,9 +308,7 @@ def is_dataclass_without_se(cls: Type[Any]) -> bool:
     return TO_DICT not in scope.funcs
 
 
-def to_obj(
-    o, named: bool, reuse_instances: bool, convert_sets: bool, c: Optional[Type[Any]] = None
-):
+def to_obj(o, named: bool, reuse_instances: bool, convert_sets: bool, c: Optional[Any] = None):
     def serializable_to_obj(object):
         serde_scope: Scope = getattr(object, SERDE_SCOPE)
         func_name = TO_DICT if named else TO_ITER
@@ -324,6 +323,13 @@ def to_obj(
             reuse_instances=reuse_instances,
             convert_sets=convert_sets,
         )
+
+        # If a class in the argument is a non-dataclass class e.g. Union[Foo, Bar],
+        # pyserde generates a wrapper (de)serializable dataclass on the fly,
+        # and use it to serialize the object.
+        if c and is_union(c) and not is_opt(c):
+            return CACHE.serialize_union(c, o)
+
         if o is None:
             return None
         if is_dataclass_without_se(o):
@@ -357,7 +363,9 @@ def astuple(v: Any) -> Tuple[Any, ...]:
     return to_tuple(v, reuse_instances=False, convert_sets=False)
 
 
-def to_tuple(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Tuple[Any, ...]:
+def to_tuple(
+    o: Any, c: Optional[Type[Any]] = None, reuse_instances: bool = ..., convert_sets: bool = ...
+) -> Tuple[Any, ...]:
     """
     Serialize object into tuple.
 
@@ -377,7 +385,7 @@ def to_tuple(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Tuple[
     >>> to_tuple(lst)
     [(10, 'foo', 100.0, True), (20, 'foo', 100.0, True)]
     """
-    return to_obj(o, named=False, reuse_instances=reuse_instances, convert_sets=convert_sets)
+    return to_obj(o, named=False, c=c, reuse_instances=reuse_instances, convert_sets=convert_sets)
 
 
 def asdict(v: Any) -> Dict[Any, Any]:
@@ -387,7 +395,9 @@ def asdict(v: Any) -> Dict[Any, Any]:
     return to_dict(v, reuse_instances=False, convert_sets=False)
 
 
-def to_dict(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Dict[Any, Any]:
+def to_dict(
+    o: Any, c: Optional[Type[Any]] = None, reuse_instances: bool = ..., convert_sets: bool = ...
+) -> Dict[Any, Any]:
     """
     Serialize object into dictionary.
 
@@ -407,7 +417,7 @@ def to_dict(o, reuse_instances: bool = ..., convert_sets: bool = ...) -> Dict[An
     >>> to_dict(lst)
     [{'i': 10, 's': 'foo', 'f': 100.0, 'b': True}, {'i': 20, 's': 'foo', 'f': 100.0, 'b': True}]
     """
-    return to_obj(o, named=True, reuse_instances=reuse_instances, convert_sets=convert_sets)
+    return to_obj(o, named=True, c=c, reuse_instances=reuse_instances, convert_sets=convert_sets)
 
 
 @dataclass
@@ -702,7 +712,7 @@ convert_sets=convert_sets), coerce(int, foo[2]),)"
         elif is_none(arg.type):
             res = "None"
         elif is_any(arg.type) or isinstance(arg.type, TypeVar):
-            res = f"to_obj({arg.varname}, True, False, False)"
+            res = f"to_obj({arg.varname}, True, False, False, c=typing.Any)"
         elif is_generic(arg.type):
             origin = get_origin(arg.type)
             assert origin

--- a/serde/toml.py
+++ b/serde/toml.py
@@ -4,7 +4,7 @@ Serialize and Deserialize in TOML format. This module depends on
 [tomli-w](https://github.com/hukkin/tomli-w) packages.
 """
 import sys
-from typing import Type, Any, overload
+from typing import Type, Any, overload, Optional
 
 import tomli_w
 
@@ -33,7 +33,9 @@ class TomlDeserializer(Deserializer[str]):
         return tomllib.loads(data, **opts)
 
 
-def to_toml(obj: Any, se: Type[Serializer[str]] = TomlSerializer, **opts: Any) -> str:
+def to_toml(
+    obj: Any, cls: Optional[Any] = None, se: Type[Serializer[str]] = TomlSerializer, **opts: Any
+) -> str:
     """
     Serialize the object into TOML.
 
@@ -43,7 +45,7 @@ def to_toml(obj: Any, se: Type[Serializer[str]] = TomlSerializer, **opts: Any) -
     If you want to use the other toml package, you can subclass `TomlSerializer` and implement
     your own logic.
     """
-    return se.serialize(to_dict(obj, reuse_instances=False), **opts)
+    return se.serialize(to_dict(obj, c=cls, reuse_instances=False), **opts)
 
 
 @overload

--- a/serde/yaml.py
+++ b/serde/yaml.py
@@ -2,7 +2,7 @@
 Serialize and Deserialize in YAML format. This module depends on
 [pyyaml](https://pypi.org/project/PyYAML/) package.
 """
-from typing import Type, Any, overload
+from typing import Type, Any, overload, Optional
 
 import yaml
 
@@ -25,7 +25,9 @@ class YamlDeserializer(Deserializer[str]):
         return yaml.safe_load(data, **opts)
 
 
-def to_yaml(obj: Any, se: Type[Serializer[str]] = YamlSerializer, **opts: Any) -> str:
+def to_yaml(
+    obj: Any, cls: Optional[Any] = None, se: Type[Serializer[str]] = YamlSerializer, **opts: Any
+) -> str:
     """
     Serialize the object into YAML.
 
@@ -35,7 +37,7 @@ def to_yaml(obj: Any, se: Type[Serializer[str]] = YamlSerializer, **opts: Any) -
     If you want to use the other yaml package, you can subclass `YamlSerializer` and implement
     your own logic.
     """
-    return se.serialize(to_dict(obj, reuse_instances=False), **opts)
+    return se.serialize(to_dict(obj, c=cls, reuse_instances=False), **opts)
 
 
 @overload


### PR DESCRIPTION
This example works correctly now

```python
@serde
@dataclass
class Foo:
    a: int

@serde
@dataclass
class Bar:
    a: int

bar = Bar(10)
s = to_json(bar)
print(s)
print(from_json(Union[Foo, Bar], s))
```

However, This will introduce a breaking change! The default
behaviour when you pass Union directly was "Untagged", but since
v0.12.0 it is "ExternalTagging".

The following code prints `{"a": 10}` until v0.11.1, but prints `{"Bar": {"a": 10}}` since v0.12.0
```python
print(to_json(bar))
```
