### PR TITLE
Fix type error when calling serde as function

### DIFF
--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -113,6 +113,14 @@ __all__ = [
 @overload
 def serde(
     _cls: Type[T],
+    rename_all: Optional[str] = None,
+    reuse_instances_default: bool = True,
+    convert_sets_default: bool = False,
+    serializer: Optional[SerializeFunc] = None,
+    deserializer: Optional[DeserializeFunc] = None,
+    tagging: Tagging = DefaultTagging,
+    type_check: TypeCheck = NoCheck,
+    serialize_class_var: bool = False,
 ) -> Type[T]:
     ...
 

--- a/serde/inspect.py
+++ b/serde/inspect.py
@@ -17,7 +17,8 @@ import logging
 import os
 import sys
 
-from typing_extensions import Type, Any
+from typing import Any
+from typing_extensions import Type
 
 from .core import SERDE_SCOPE, SerdeScope, init, logger
 


### PR DESCRIPTION
No warning is raised for this case.
```
serde(None, tagging=InternalTagging("type"))
```