### PR TITLE
Fix mypy error for Optional and Union in (de)serialize APIs

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -9,7 +9,7 @@ import dataclasses
 import functools
 import typing
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic, overload
 
 import jinja2
 from typing_extensions import Type, dataclass_transform
@@ -472,7 +472,17 @@ def from_obj(c: Type[T], o: Any, named: bool, reuse_instances: bool) -> T:
         raise SerdeError(e) from None
 
 
-def from_dict(cls: Type[T], o, reuse_instances: bool = ...) -> T:
+@overload
+def from_dict(cls: Type[T], o: Dict[str, Any], reuse_instances: bool = ...) -> T:
+    ...
+
+
+@overload
+def from_dict(cls: Any, o: Dict[str, Any], reuse_instances: bool = ...) -> Any:
+    ...
+
+
+def from_dict(cls: Any, o: Dict[str, Any], reuse_instances: bool = ...) -> Any:
     """
     Deserialize dictionary into object.
 
@@ -495,7 +505,17 @@ def from_dict(cls: Type[T], o, reuse_instances: bool = ...) -> T:
     return from_obj(cls, o, named=True, reuse_instances=reuse_instances)
 
 
+@overload
 def from_tuple(cls: Type[T], o: Any, reuse_instances: bool = ...) -> T:
+    ...
+
+
+@overload
+def from_tuple(cls: Any, o: Any, reuse_instances: bool = ...) -> Any:
+    ...
+
+
+def from_tuple(cls: Any, o: Any, reuse_instances: bool = ...) -> Any:
     """
     Deserialize tuple into object.
 

--- a/serde/json.py
+++ b/serde/json.py
@@ -1,7 +1,7 @@
 """
 Serialize and Deserialize in JSON format.
 """
-from typing import Any
+from typing import Any, overload
 
 from typing_extensions import Type
 
@@ -65,7 +65,18 @@ def to_json(obj: Any, se: Type[Serializer[str]] = JsonSerializer, **opts: Any) -
     return se.serialize(to_dict(obj, reuse_instances=False, convert_sets=True), **opts)
 
 
+@overload
 def from_json(c: Type[T], s: str, de: Type[Deserializer[str]] = JsonDeserializer, **opts: Any) -> T:
+    ...
+
+
+# For Union, Optional etc.
+@overload
+def from_json(c: Any, s: str, de: Type[Deserializer[str]] = JsonDeserializer, **opts: Any) -> Any:
+    ...
+
+
+def from_json(c: Any, s: str, de: Type[Deserializer[str]] = JsonDeserializer, **opts: Any) -> Any:
     """
     Deserialize from JSON into the object. [orjson](https://github.com/ijl/orjson) will be used if installed.
 

--- a/serde/msgpack.py
+++ b/serde/msgpack.py
@@ -2,7 +2,7 @@
 Serialize and Deserialize in MsgPack format. This module depends on
 [msgpack](https://pypi.org/project/msgpack/) package.
 """
-from typing import Any, Dict, Type, Optional
+from typing import Any, Dict, Type, Optional, overload
 
 import msgpack
 
@@ -68,6 +68,7 @@ def to_msgpack(
     )
 
 
+@overload
 def from_msgpack(
     c: Type[T],
     s: bytes,
@@ -76,6 +77,29 @@ def from_msgpack(
     ext_dict: Optional[Dict[int, Type[Any]]] = None,
     **opts: Any,
 ) -> T:
+    ...
+
+
+@overload
+def from_msgpack(
+    c: Any,
+    s: bytes,
+    de: Type[Deserializer[bytes]] = MsgPackDeserializer,
+    named: bool = True,
+    ext_dict: Optional[Dict[int, Type[Any]]] = None,
+    **opts: Any,
+) -> Any:
+    ...
+
+
+def from_msgpack(
+    c: Any,
+    s: bytes,
+    de: Type[Deserializer[bytes]] = MsgPackDeserializer,
+    named: bool = True,
+    ext_dict: Optional[Dict[int, Type[Any]]] = None,
+    **opts: Any,
+) -> Any:
     """
     Deserialize from MsgPack into the object.
 
@@ -90,7 +114,7 @@ def from_msgpack(
         ext_type = ext_dict.get(ext.code)
         if ext_type is None:
             raise SerdeError(f"Could not find type for code {ext.code} in ext_dict")
-        return from_msgpack(ext_type, ext.data, de, named, **opts)  # type: ignore
+        return from_msgpack(ext_type, ext.data, de, named, **opts)
     else:
         from_func = from_dict if named else from_tuple
         return from_func(c, de.deserialize(s, **opts), reuse_instances=False)

--- a/serde/pickle.py
+++ b/serde/pickle.py
@@ -2,7 +2,7 @@
 Serialize and Deserialize in Pickle format.
 """
 import pickle
-from typing import Type, Any
+from typing import Type, Any, overload
 
 from .compat import T
 from .de import Deserializer, from_dict
@@ -27,5 +27,16 @@ def to_pickle(obj: Any, se: Type[Serializer[bytes]] = PickleSerializer, **opts: 
     return se.serialize(to_dict(obj, reuse_instances=False), **opts)
 
 
+@overload
 def from_pickle(c: Type[T], data: bytes, de: Type[Deserializer[bytes]] = PickleDeserializer, **opts: Any) -> T:
+    ...
+
+
+@overload
+def from_pickle(c: Any, data: bytes, de: Type[Deserializer[bytes]] = PickleDeserializer, **opts: Any) -> Any:
+    ...
+
+
+# For Union, Optional etc.
+def from_pickle(c: Any, data: bytes, de: Type[Deserializer[bytes]] = PickleDeserializer, **opts: Any) -> Any:
     return from_dict(c, de.deserialize(data, **opts), reuse_instances=False)

--- a/serde/toml.py
+++ b/serde/toml.py
@@ -3,7 +3,7 @@ Serialize and Deserialize in TOML format. This module depends on [tomli](https:/
 (for python<=3.10) and [tomli-w](https://github.com/hukkin/tomli-w) packages.
 """
 import sys
-from typing import Type, Any
+from typing import Type, Any, overload
 
 import tomli_w
 
@@ -44,7 +44,18 @@ def to_toml(obj: Any, se: Type[Serializer[str]] = TomlSerializer, **opts: Any) -
     return se.serialize(to_dict(obj, reuse_instances=False), **opts)
 
 
+@overload
 def from_toml(c: Type[T], s: str, de: Type[Deserializer[str]] = TomlDeserializer, **opts: Any) -> T:
+    ...
+
+
+# For Union, Optional etc.
+@overload
+def from_toml(c: Any, s: str, de: Type[Deserializer[str]] = TomlDeserializer, **opts: Any) -> Any:
+    ...
+
+
+def from_toml(c: Any, s: str, de: Type[Deserializer[str]] = TomlDeserializer, **opts: Any) -> Any:
     """
     Deserialize from TOML into the object.
 

--- a/serde/yaml.py
+++ b/serde/yaml.py
@@ -1,7 +1,7 @@
 """
 Serialize and Deserialize in YAML format. This module depends on [pyyaml](https://pypi.org/project/PyYAML/) package.
 """
-from typing import Type, Any
+from typing import Type, Any, overload
 
 import yaml
 
@@ -36,7 +36,18 @@ def to_yaml(obj: Any, se: Type[Serializer[str]] = YamlSerializer, **opts: Any) -
     return se.serialize(to_dict(obj, reuse_instances=False), **opts)
 
 
+@overload
 def from_yaml(c: Type[T], s: str, de: Type[Deserializer[str]] = YamlDeserializer, **opts: Any) -> T:
+    ...
+
+
+# For Union, Optional etc.
+@overload
+def from_yaml(c: Any, s: str, de: Type[Deserializer[str]] = YamlDeserializer, **opts: Any) -> Any:
+    ...
+
+
+def from_yaml(c: Any, s: str, de: Type[Deserializer[str]] = YamlDeserializer, **opts: Any) -> Any:
     """
     `c` is a class obejct and `s` is YAML string. If you supply keyword arguments other than `de`,
     they will be passed in `yaml.safe_load` function.


### PR DESCRIPTION
(de)serialize APIs take a type object in the 1st argument. Union and Optional is not a subclass of "type", so we got a mypy error in the following code.

```
v = from_json(Optional[int], s)
```

typing.overload is used to specifying "Any" as well as "Type[T]".

Closes #358 