### PR TITLE
Fix variable length tuple codegen

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -9,7 +9,7 @@ import dataclasses
 import functools
 import typing
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic, overload
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, overload
 
 import jinja2
 from typing_extensions import Type, dataclass_transform
@@ -779,8 +779,10 @@ Foo.__serde__.funcs[\\'foo\\'](data=data["d"][3], maybe_generic=maybe_generic, r
 [coerce(int, v) for v in data[0][2]], Foo.__serde__.funcs['foo'](data=data[0][3], \
 maybe_generic=maybe_generic, reuse_instances=reuse_instances),)"
         """
-        if is_bare_tuple(arg.type) or is_variable_tuple(arg.type):
+        if is_bare_tuple(arg.type):
             return f"tuple({arg.data})"
+        elif is_variable_tuple(arg.type):
+            return f"tuple({self.render(arg[0])} for v in {arg.data})"
         else:
             values = []
             for i, _typ in enumerate(type_args(arg.type)):

--- a/serde/de.py
+++ b/serde/de.py
@@ -782,7 +782,9 @@ maybe_generic=maybe_generic, reuse_instances=reuse_instances),)"
         if is_bare_tuple(arg.type):
             return f"tuple({arg.data})"
         elif is_variable_tuple(arg.type):
-            return f"tuple({self.render(arg[0])} for v in {arg.data})"
+            earg = arg[0]
+            earg.datavar = "v"
+            return f"tuple({self.render(earg)} for v in {arg.data})"
         else:
             values = []
             for i, _typ in enumerate(type_args(arg.type)):

--- a/serde/se.py
+++ b/serde/se.py
@@ -9,16 +9,16 @@ import dataclasses
 import functools
 import typing
 from dataclasses import dataclass, is_dataclass
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Generic
+from typing import Any, Callable, Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 
 import jinja2
 from typing_extensions import dataclass_transform
 
 from .compat import (
-    T,
     Literal,
     SerdeError,
     SerdeSkip,
+    T,
     get_origin,
     is_any,
     is_bare_dict,
@@ -757,8 +757,12 @@ convert_sets=convert_sets), coerce(int, foo[2]),)"
         """
         Render rvalue for tuple.
         """
-        if is_bare_tuple(arg.type) or is_variable_tuple(arg.type):
+        if is_bare_tuple(arg.type):
             return arg.varname
+        elif is_variable_tuple(arg.type):
+            earg = arg[0]
+            earg.name = "v"
+            return f"tuple({self.render(earg)} for v in {arg.varname})"
         else:
             rvalues = []
             for i, _ in enumerate(type_args(arg.type)):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -317,13 +317,19 @@ def test_tuple(se, de, opt):
 
     @serde.serde(**opt)
     @dataclasses.dataclass
+    class Inner:
+        i: int
+
+    @serde.serde(**opt)
+    @dataclasses.dataclass
     class VariableTuple:
         t: Tuple[int, ...]
+        i: Tuple[Inner, ...]
 
-    e = VariableTuple((1, 2, 3))
+    e = VariableTuple((1, 2, 3), (Inner(0), Inner(1)))
     assert e == de(VariableTuple, se(e))
 
-    e = VariableTuple(())
+    e = VariableTuple((), ())
     assert e == de(VariableTuple, se(e))
 
     with pytest.raises(Exception):


### PR DESCRIPTION
This fixes an issue where if you have a variable length tuple whose elements are `dataclass`, it doesn't properly codegen tuple-parsing logic for the elements. 

Example:
```python
from serde import serde, to_dict
from dataclasses import dataclass

@serde
@dataclass
class Foo:
    a: int
    
@serde
@dataclass
class Bar:
    foos: tuple[Foo, ...]
    
bar = Bar(foos=(Foo(0), Foo(1)))
to_dict(bar)
```
```
# old output
{'foos': (Foo(a=0), Foo(a=1))}

# new output
{'foos': ({'a': 0}, {'a': 1})}
```