### PR TITLE
Support (de)serialize a subclass of primitive type

### DIFF
--- a/examples/primitive_subclass.py
+++ b/examples/primitive_subclass.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from serde.json import from_json, to_json
+from serde import field, serde
+from typing import Dict, List
+
+
+class Id(str):
+    def __str__(self) -> str:
+        return "ID " + self
+
+
+@serde
+@dataclass
+class Foo:
+    a: Id = field(default_factory=Id)
+    b: Dict[Id, float] = field(default_factory=dict)
+    c: List[Id] = field(default_factory=list)
+
+
+def main() -> None:
+    f = Foo(Id("a"), {Id("b"): 1.0}, [Id("c")])
+    print(f)
+    print(type(f.a))
+    print(type(list(f.b.keys())[0]))
+    print(type(f.c[0]))
+
+    d = to_json(f)
+    print(d)
+
+    ff = from_json(Foo, d)
+    print(ff)
+    print(type(ff.a))
+    print(type(list(ff.b.keys())[0]))
+    print(type(ff.c[0]))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -3,6 +3,7 @@ import sys
 import alias
 import any
 import class_var
+import primitive_subclass
 import collection
 import custom_class_serializer
 import custom_field_serializer
@@ -93,6 +94,7 @@ def run_all() -> None:
     run(plain_dataclass)
     run(plain_dataclass_class_attribute)
     run(msg_pack)
+    run(primitive_subclass)
     if PY310:
         import union_operator
 

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -705,6 +705,20 @@ def is_enum(typ: Type[Any]) -> TypeGuard[enum.Enum]:
         return isinstance(typ, enum.Enum)
 
 
+def is_primitive_subclass(typ: Type[Any]) -> bool:
+    """
+    Test if the type is a subclass of primitive type.
+
+    >>> is_primitive_subclass(str)
+    False
+    >>> class Str(str):
+    ...     pass
+    >>> is_primitive_subclass(Str)
+    True
+    """
+    return is_primitive(typ) and typ not in PRIMITIVES and not is_new_type_primitive(typ)
+
+
 def is_primitive(typ: Type[Any]) -> bool:
     """
     Test if the type is primitive.

--- a/serde/de.py
+++ b/serde/de.py
@@ -43,6 +43,7 @@ from .compat import (
     is_none,
     is_opt,
     is_primitive,
+    is_primitive_subclass,
     is_set,
     is_str_serializable,
     is_tuple,
@@ -245,8 +246,13 @@ def deserialize(
                 # We call deserialize and not wrap to make sure that we will use the default serde
                 # configuration for generating the deserialization function.
                 deserialize(typ)
-            if is_primitive(typ) and not is_enum(typ):
+
+            # We don't want to add primitive class e.g "str" into the scope, but primitive
+            # compatible types such as IntEnum and a subclass of primitives are added,
+            # so that generated code can use those types.
+            if is_primitive(typ) and not is_enum(typ) and not is_primitive_subclass(typ):
                 continue
+
             if is_generic(typ):
                 g[typename(typ)] = get_origin(typ)
             else:
@@ -626,6 +632,7 @@ class Renderer:
     custom: Optional[DeserializeFunc] = None  # Custom class level deserializer.
     import_numpy: bool = False
     suppress_coerce: bool = False
+    """ Disable type coercing in codegen """
 
     def render(self, arg: DeField[Any]) -> str:
         """
@@ -657,8 +664,6 @@ class Renderer:
         elif is_numpy_array(arg.type):
             self.import_numpy = True
             res = deserialize_numpy_array(arg)
-        elif is_primitive(arg.type):
-            res = self.primitive(arg)
         elif is_union(arg.type):
             res = self.union_func(arg)
         elif is_str_serializable(arg.type):
@@ -671,6 +676,9 @@ class Renderer:
             res = "None"
         elif is_any(arg.type) or is_ellipsis(arg.type):
             res = arg.data
+        elif is_primitive(arg.type):
+            # For subclasses for primitives e.g. class FooStr(str), coercing is always enabled
+            res = self.primitive(arg, not is_primitive_subclass(arg.type))
         elif isinstance(arg.type, TypeVar):
             index = find_generic_arg(self.cls, arg.type)
             res = (
@@ -878,6 +886,8 @@ variable_type_args=None, reuse_instances=reuse_instances) for v in v] for k, v i
         """
         Render rvalue for primitives.
 
+        * `suppress_coerce`: Overrides "suppress_coerce" in the Renderer's field
+
         >>> Renderer('foo').render(DeField(int, 'i', datavar='data'))
         'coerce(int, data["i"])'
 
@@ -892,7 +902,7 @@ variable_type_args=None, reuse_instances=reuse_instances) for v in v] for k, v i
         if arg.alias:
             aliases = (f'"{s}"' for s in [arg.name, *arg.alias])
             dat = f"_get_by_aliases(data, [{','.join(aliases)}])"
-        if self.suppress_coerce:
+        if self.suppress_coerce and suppress_coerce:
             return dat
         else:
             return f"coerce({typ}, {dat})"

--- a/tests/common.py
+++ b/tests/common.py
@@ -71,8 +71,12 @@ def param(val, typ, filter: Optional[Callable] = None):
     return (val, typ, filter or (lambda se, de, opt: False))
 
 
-def toml_not_supported(se, de, opt) -> bool:
+def toml_not_supported(se: Any, de: Any, opt: Any) -> bool:
     return se is to_toml
+
+
+def yaml_not_supported(se: Any, de: Any, opt: Any) -> bool:
+    return se is to_yaml
 
 
 types: List = [
@@ -103,6 +107,7 @@ types: List = [
     param({"a": [1]}, DefaultDict[str, List[int]]),
     param(data.Pri(10, "foo", 100.0, True), data.Pri),  # dataclass
     param(data.Pri(10, "foo", 100.0, True), Optional[data.Pri]),
+    param(data.PrimitiveSubclass(data.StrSubclass("a")), data.PrimitiveSubclass, yaml_not_supported),
     param(None, Optional[data.Pri], toml_not_supported),
     param(data.Recur(data.Recur(None, None, None), None, None), data.Recur, toml_not_supported),
     param(

--- a/tests/data.py
+++ b/tests/data.py
@@ -276,3 +276,13 @@ class Init:
 
     def __post_init__(self) -> None:
         self.b = self.a * 10
+
+
+class StrSubclass(str):
+    pass
+
+
+@serde
+@dataclass
+class PrimitiveSubclass:
+    v: StrSubclass


### PR DESCRIPTION
Now pyserde supports a class

```
class Str(str):
    pass
```

NOTE:
Some serialize APIs e.g to_yaml doesn't support subclasses of primitive types. You will get an exception like below

```
yaml.representer.RepresenterError: ('cannot represent an object', 'a')
```

Closes #383 