### PR TITLE
Fix frozen dataclass inheritance

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -881,9 +881,6 @@ def should_impl_dataclass(cls: Type[Any]) -> bool:
     if not annotations:
         return False
 
-    if len(annotations) != len(dataclasses.fields(cls)):
-        return True
-
     field_names = [field.name for field in dataclass_fields(cls)]
     for field_name in annotations:
         if field_name not in field_names:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1271,3 +1271,18 @@ def test_deserialize_from_incompatible_value() -> None:
         assert serde.from_dict(Foo, "")
     with pytest.raises(serde.SerdeError):
         assert serde.from_dict(Foo, 10)
+
+
+def test_frozen_dataclass() -> None:
+    @serde.serde
+    @dataclasses.dataclass(frozen=True)
+    class Foo:
+        a: int
+
+    @serde.serde
+    @dataclasses.dataclass(frozen=True)
+    class Bar(Foo):
+        b: int
+
+    bar = Bar(a=10, b=20)
+    assert bar == serde.from_dict(Bar, serde.to_dict(bar))


### PR DESCRIPTION
Fix frozen dataclass inheritance

`should_impl_dataclass` should not compare the length of declared
fields as `dataclasses.field` might include inherited fields but
`__annotations__` does not.

This commit allows to declare frozen dataclass to inherit from
another frozen dataclass.

```python
@serde
@dataclass(frozen=True)
class Foo:
    a: int

@serde
@dataclass(frozen=True)
class Bar(Foo):
    b: int
```

However, there is still an issue. It seems type checkers e.g. mypy
and pyright can not correctly understand the frozen pyserde class
due to the limitation of `dataclass_transform`. You will get a type
error "A frozen class cannot inherit from a class that is not frozen"

https://peps.python.org/pep-0681/#dataclass-semantics

The PEP681 says
> A class that has been decorated with dataclass_transform is
considered neither frozen nor non-frozen

If you are mypy/pyright user, I'd suggest to declare dataclass
without serde decorator as a workaround. This way won't produce
any type errors.

```python
@dataclass(frozen=True)
class Foo:
    a: int

@dataclass(frozen=True)
class Bar(Foo):
    b: int
```
