### PR TITLE
Do not shallow clone when publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        fetch-depth: 0
       - name: Install poetry
         run: pip install poetry poetry-dynamic-versioning
       - name: Set up Python 3.10


### PR DESCRIPTION
It is required by poetry-dynamic-versioning
https://github.com/mtkennerly/dunamai#other-notes