### PR TITLE
Fix name 'Set' is not defined error

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -385,8 +385,14 @@ def iter_types(cls: TypeLike) -> List[TypeLike]:
             lst.add(Union)
             for arg in type_args(cls):
                 recursive(arg)
-        elif is_list(cls) or is_set(cls):
+        elif is_list(cls):
             lst.add(List)
+            args = type_args(cls)
+            if args:
+                recursive(args[0])
+        elif is_set(cls):
+            lst.add(List)
+            lst.add(Set)
             args = type_args(cls)
             if args:
                 recursive(args[0])

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -391,7 +391,6 @@ def iter_types(cls: TypeLike) -> List[TypeLike]:
             if args:
                 recursive(args[0])
         elif is_set(cls):
-            lst.add(List)
             lst.add(Set)
             args = type_args(cls)
             if args:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -98,6 +98,7 @@ def test_iter_types():
     assert {Pri, int, str, float, bool} == set(iter_types(Pri))
     assert {Dict, str, Pri, int, float, bool} == set(iter_types(Dict[str, Pri]))
     assert {List, str} == set(iter_types(List[str]))
+    assert {List, Set, str} == set(iter_types(Set[str]))
     assert {Tuple, int, str, bool, float} == set(iter_types(Tuple[int, str, bool, float]))
     assert {Tuple, int, Ellipsis} == set(iter_types(Tuple[int, ...]))
     assert {PriOpt, Optional, int, str, float, bool} == set(iter_types(PriOpt))
@@ -110,8 +111,9 @@ def test_iter_types():
         d: Optional[str] = None
         e: Union[str, int] = 10
         f: List[int] = serde.field(default_factory=list)
+        g: Set = serde.field(default_factory=set)
 
-    assert {Foo, datetime, Optional, str, Union, List, int} == set(iter_types(Foo))
+    assert {Foo, datetime, Optional, str, Union, List, Set, int} == set(iter_types(Foo))
 
 
 def test_iter_unions():

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -98,7 +98,7 @@ def test_iter_types():
     assert {Pri, int, str, float, bool} == set(iter_types(Pri))
     assert {Dict, str, Pri, int, float, bool} == set(iter_types(Dict[str, Pri]))
     assert {List, str} == set(iter_types(List[str]))
-    assert {List, Set, str} == set(iter_types(Set[str]))
+    assert {Set, str} == set(iter_types(Set[str]))
     assert {Tuple, int, str, bool, float} == set(iter_types(Tuple[int, str, bool, float]))
     assert {Tuple, int, Ellipsis} == set(iter_types(Tuple[int, ...]))
     assert {PriOpt, Optional, int, str, float, bool} == set(iter_types(PriOpt))

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -111,7 +111,7 @@ def test_iter_types():
         d: Optional[str] = None
         e: Union[str, int] = 10
         f: List[int] = serde.field(default_factory=list)
-        g: Set = serde.field(default_factory=set)
+        g: Set[int] = serde.field(default_factory=set)
 
     assert {Foo, datetime, Optional, str, Union, List, Set, int} == set(iter_types(Foo))
 

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -2,7 +2,7 @@
 Tests for custom serializer/deserializer.
 """
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Set
 
 import pytest
 
@@ -92,14 +92,18 @@ def test_custom_class_serializer():
         d: Optional[str] = None
         e: Union[str, int] = 10
         f: List[int] = field(default_factory=list)
+        g: Set[str] = field(default_factory=set)
 
     dt = datetime(2021, 1, 1, 0, 0, 0)
-    f = Foo(10, dt, dt, f=[1, 2, 3])
+    f = Foo(10, dt, dt, f=[1, 2, 3], g={4, 5, 6})
 
-    assert to_json(f) == '{"a":10,"b":"01/01/21","c":"01/01/21","d":null,"e":10,"f":[1,2,3]}'
+    assert (
+        to_json(f)
+        == '{"a":10,"b":"01/01/21","c":"01/01/21","d":null,"e":10,"f":[1,2,3],"g":[4,5,6]}'
+    )
     assert f == from_json(Foo, to_json(f))
 
-    assert to_tuple(f) == (10, "01/01/21", "01/01/21", None, 10, [1, 2, 3])
+    assert to_tuple(f) == (10, "01/01/21", "01/01/21", None, 10, [1, 2, 3], {4, 5, 6})
     assert f == from_tuple(Foo, to_tuple(f))
 
     def fallback(_, __):

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -92,7 +92,7 @@ def test_custom_class_serializer():
         d: Optional[str] = None
         e: Union[str, int] = 10
         f: List[int] = field(default_factory=list)
-        g: Set[str] = field(default_factory=set)
+        g: Set[int] = field(default_factory=set)
 
     dt = datetime(2021, 1, 1, 0, 0, 0)
     f = Foo(10, dt, dt, f=[1, 2, 3], g={4, 5, 6})


### PR DESCRIPTION
Fixes: https://github.com/yukinarit/pyserde/issues/444

Adds `Set` in `iter_types` so that it is included in the globals of the generated functions so it can be used in the custom serializer generated code