### PR TITLE
Fix `skip_if` causing serialization of a recursive type to be `O(2**n)` instead of `O(n)`

### DIFF
--- a/serde/se.py
+++ b/serde/se.py
@@ -553,8 +553,9 @@ def {{func}}(obj, reuse_instances = None, convert_sets = None):
   {% for f in fields -%}
   {% if not f.skip -%}
     {% if f.skip_if -%}
-  if not {{f.skip_if.name}}({{f|rvalue}}):
-    {{f|lvalue}} = {{f|rvalue}}
+  subres = {{f|rvalue}}
+  if not {{f.skip_if.name}}(subres):
+    {{f|lvalue}} = subres
     {% else -%}
   {{f|lvalue}} = {{f|rvalue}}
     {% endif -%}


### PR DESCRIPTION
fixes #451.

i was not sure where to add a test for this, as it's an (exponential) performance issue rather than a correctness issue. a pointer would be much appreciated!

note that once Python 3.7 support is dropped (#418), this is a perfect use-case for the `:=` operator.