### PR TITLE
Implement new class (de)serializer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Remove pypy-3.8 until it supports numpy
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]  # "pypy-3.8"
+        python-version: ["3.8", "3.9", "3.10", "3.11"]  # "pypy-3.8"
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry

--- a/docs/en/class-attributes.md
+++ b/docs/en/class-attributes.md
@@ -70,7 +70,40 @@ See [examples/rename_all.py](https://github.com/yukinarit/pyserde/blob/main/exam
 
 New in v0.7.0. See [Union](union.md).
 
+### **`class_serializer`** / **`class_deserializer`**
+
+If you want to use a custom (de)serializer at class level, you can pass your (de)serializer object in `class_serializer` and `class_deserializer` class attributes. Class custom (de)serializer depends on a python library [plum](https://github.com/beartype/plum) which allows multiple method overloading like C++. With plum, you can write robust custom (de)serializer in a quite neat way.
+
+```python
+class MySerializer(ClassSerializer):
+    @dispatch
+    def serialize(self, value: datetime) -> str:
+        return value.strftime("%d/%m/%y")
+
+class MyDeserializer(ClassDeserializer):
+    @dispatch
+    def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+        return datetime.strptime(value, "%d/%m/%y")
+
+@serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+@dataclass
+class Foo:
+    v: datetime
+```
+
+One big difference from legacy `serializer` and `deserializer` is the fact that new `class_serializer` and `class_deserializer` are more deeply integrated at the pyserde's code generator level. You no longer need to handle Optional, List and Nested dataclass by yourself. Custom class (de)serializer will be used at all level of (de)serialization so you can extend pyserde to support third party types just like builtin types.
+
+Also,
+* If both field and class serializer specified, field serializer is prioritized
+* If both legacy and new class serializer specified, new class serializer is prioritized
+
+See [examples/custom_class_serializer.py](https://github.com/yukinarit/pyserde/blob/main/examples/custom_class_serializer.py) for complete example.
+
+New in v0.13.0.
+
 ### **`serializer`** / **`deserializer`**
+
+> **NOTE:** Deprecated since v0.13.0. Consider using `class_serializer` and `class_deserializer`.
 
 If you want to use a custom (de)serializer at class level, you can pass your (de)serializer methods n `serializer` and `deserializer` class attributes.
 
@@ -93,7 +126,7 @@ class Foo:
     a: datetime
 ```
 
-See [examples/custom_class_serializer.py](https://github.com/yukinarit/pyserde/blob/main/examples/custom_class_serializer.py) for complete example.
+See [examples/custom_legacy_class_serializer.py](https://github.com/yukinarit/pyserde/blob/main/examples/custom_legacy_class_serializer.py) for complete example.
 
 ### **`type_check`**
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Install pyserde from PyPI. pyserde requires Python>=3.7.
+Install pyserde from PyPI. pyserde requires Python>=3.8.
 
 ```
 pip install pyserde

--- a/examples/custom_class_serializer.py
+++ b/examples/custom_class_serializer.py
@@ -1,55 +1,45 @@
+from plum import dispatch
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Type, Any
-
-from serde import SerdeSkip, default_deserializer, default_serializer, field, serde
+from serde import (
+    serde,
+    ClassSerializer,
+    ClassDeserializer,
+    field,
+)
 from serde.json import from_json, to_json
+from typing import Type, Any, List
 
 
-def serializer(cls: Type[Any], o: Any) -> str:
-    """
-    Custom class level serializer.
-    """
-
-    # You can provide a custom serialize/deserialize logic for certain types.
-    if cls is datetime:
-        # I don't know why but this is untyped in typeshed
-        return o.strftime("%d/%m/%y")  # type: ignore
-    # Raise SerdeSkip to tell serde to use the default serializer/deserializer.
-    else:
-        raise SerdeSkip()
+class MySerializer(ClassSerializer):
+    @dispatch
+    def serialize(self, value: datetime) -> str:
+        return value.strftime("%d/%m/%y")
 
 
-def deserializer(cls: Type[Any], o: Any) -> datetime:
-    """
-    Custom class level deserializer.
-    """
-    if cls is datetime:
-        return datetime.strptime(o, "%d/%m/%y")
-    else:
-        raise SerdeSkip()
+class MyDeserializer(ClassDeserializer):
+    @dispatch
+    def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+        return datetime.strptime(value, "%d/%m/%y")
 
 
-@serde(serializer=serializer, deserializer=deserializer)
+@serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
 @dataclass
 class Foo:
-    i: int
-    dt1: datetime
-    # Override by field serializer/deserializer.
-    dt2: datetime = field(
+    a: datetime
+    b: datetime = field(
         serializer=lambda x: x.strftime("%y.%m.%d"),
         deserializer=lambda x: datetime.strptime(x, "%y.%m.%d"),
     )
-    # Override by the default serializer/deserializer.
-    dt3: datetime = field(serializer=default_serializer, deserializer=default_deserializer)
+    c: List[datetime] = field(default_factory=list)
 
 
 def main() -> None:
     dt = datetime(2021, 1, 1, 0, 0, 0)
-    f = Foo(10, dt, dt, dt)
+    f = Foo(dt, dt, [dt])
     print(f"Into Json: {to_json(f)}")
 
-    s = '{"i": 10, "dt1": "01/01/21", "dt2": "01.01.21", "dt3": "2021-01-01T00:00:00"}'
+    s = '{"a": "01/01/21", "b": "01.01.21", "c": ["01/01/21"]}'
     print(f"From Json: {from_json(Foo, s)}")
 
 

--- a/examples/custom_legacy_class_serializer.py
+++ b/examples/custom_legacy_class_serializer.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Type, Any
+
+from serde import SerdeSkip, default_deserializer, default_serializer, field, serde
+from serde.json import from_json, to_json
+
+
+def serializer(cls: Type[Any], o: Any) -> str:
+    """
+    Custom class level serializer.
+    """
+
+    # You can provide a custom serialize/deserialize logic for certain types.
+    if cls is datetime:
+        # I don't know why but this is untyped in typeshed
+        return o.strftime("%d/%m/%y")  # type: ignore
+    # Raise SerdeSkip to tell serde to use the default serializer/deserializer.
+    else:
+        raise SerdeSkip()
+
+
+def deserializer(cls: Type[Any], o: Any) -> datetime:
+    """
+    Custom class level deserializer.
+    """
+    if cls is datetime:
+        return datetime.strptime(o, "%d/%m/%y")
+    else:
+        raise SerdeSkip()
+
+
+@serde(serializer=serializer, deserializer=deserializer)
+@dataclass
+class Foo:
+    a: datetime
+    # Override by field serializer/deserializer.
+    b: datetime = field(
+        serializer=lambda x: x.strftime("%y.%m.%d"),
+        deserializer=lambda x: datetime.strptime(x, "%y.%m.%d"),
+    )
+    # Override by the default serializer/deserializer.
+    c: datetime = field(serializer=default_serializer, deserializer=default_deserializer)
+
+
+def main() -> None:
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(dt, dt, dt)
+    print(f"Into Json: {to_json(f)}")
+
+    s = '{"a": "01/01/21", "b": "01.01.21", "c": "2021-01-01T00:00:00"}'
+    print(f"From Json: {from_json(Foo, s)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -6,6 +6,7 @@ import class_var
 import primitive_subclass
 import collection
 import custom_class_serializer
+import custom_legacy_class_serializer
 import custom_field_serializer
 import default
 import default_dict
@@ -69,6 +70,7 @@ def run_all() -> None:
     run(yamlfile)
     run(union)
     run(custom_class_serializer)
+    run(custom_legacy_class_serializer)
     run(custom_field_serializer)
     run(forward_reference)
     run(type_decimal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,19 +14,19 @@ classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
 		"Programming Language :: Python :: Implementation :: PyPy",
     ]
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
+python = "^3.8.0"
 typing_inspect = ">=0.4.0"
-typing_extensions = { version = ">=4.1.0", markers = "python_version ~= '3.7.0'" }
+typing_extensions = { version = ">=4.1.0" }
 casefy = "*"
 jinja2 = "*"
 msgpack = { version = "*", markers = "extra == 'msgpack' or extra == 'all'", optional = true }
@@ -34,12 +34,12 @@ tomli = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional
 tomli-w = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional = true }
 pyyaml = { version = "*", markers = "extra == 'yaml' or extra == 'all'", optional = true }
 numpy = [
-    { version = ">1.21.0", markers = "python_version ~= '3.7.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.21.0", markers = "python_version ~= '3.8.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
     { version = ">1.22.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]
 orjson = { version = "*", markers = "extra == 'orjson' or extra == 'all'", optional = true }
+plum-dispatch = "^2"
 
 [tool.poetry.dev-dependencies]
 pyyaml = "*"
@@ -47,7 +47,6 @@ tomli = { version = "*", markers = "python_version <= '3.11.0'" }
 tomli-w = "*"
 msgpack = "*"
 numpy = [
-    { version = ">1.21.0", markers = "python_version ~= '3.7.0'" },
     { version = ">1.21.0", markers = "python_version ~= '3.8.0'" },
     { version = ">1.21.0", markers = "python_version ~= '3.9.0'" },
     { version = ">1.22.0", markers = "python_version ~= '3.10'" },
@@ -98,12 +97,27 @@ include = [
   "serde/msgpack.py",
   "serde/toml.py",
   "serde/yaml.py",
-  "serde/pickle.py"
+  "serde/pickle.py",
+  "tests/test_custom.py",
 ]
 exclude = [
   "serde/numpy.py",
   "bench",
-  "tests",
+  "tests/common.py",
+  "tests/data.py",
+  "tests/imported.py",
+  "tests/test_basics.py",
+  "tests/test_compat.py",
+  "tests/test_core.py",
+  "tests/test_de.py",
+  "tests/test_flatten.py",
+  "tests/test_kwonly.py",
+  "tests/test_lazy_type_evaluation.py",
+  "tests/test_legacy_custom.py",
+  "tests/test_literal.py",
+  "tests/test_numpy.py",
+  "tests/test_se.py",
+  "tests/test_union.py",
   "serde/__init__.py"
 ]
 pythonVersion = "3.11"
@@ -117,7 +131,21 @@ exclude = [
   "examples/alias.py",
   "examples/field_order.py",
   "bench",
-  "tests"
+  "tests/common.py",
+  "tests/data.py",
+  "tests/imported.py",
+  "tests/test_basics.py",
+  "tests/test_compat.py",
+  "tests/test_core.py",
+  "tests/test_de.py",
+  "tests/test_flatten.py",
+  "tests/test_kwonly.py",
+  "tests/test_lazy_type_evaluation.py",
+  "tests/test_legacy_custom.py",
+  "tests/test_literal.py",
+  "tests/test_numpy.py",
+  "tests/test_se.py",
+  "tests/test_union.py",
 ]
 
 [tool.ruff]

--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -28,6 +28,8 @@ from typing_extensions import dataclass_transform
 
 from .compat import SerdeError, SerdeSkip, T
 from .core import (
+    ClassSerializer,
+    ClassDeserializer,
     AdjacentTagging,
     Coerce,
     DefaultTagging,
@@ -99,6 +101,8 @@ __all__ = [
     "yaml",
     "init",
     "logger",
+    "ClassSerializer",
+    "ClassDeserializer",
 ]
 
 
@@ -113,6 +117,8 @@ def serde(
     tagging: Tagging = DefaultTagging,
     type_check: TypeCheck = NoCheck,
     serialize_class_var: bool = False,
+    class_serializer: Optional[ClassSerializer] = None,
+    class_deserializer: Optional[ClassDeserializer] = None,
 ) -> Type[T]:
     ...
 
@@ -127,6 +133,8 @@ def serde(
     tagging: Tagging = DefaultTagging,
     type_check: TypeCheck = NoCheck,
     serialize_class_var: bool = False,
+    class_serializer: Optional[ClassSerializer] = None,
+    class_deserializer: Optional[ClassDeserializer] = None,
 ) -> Callable[[Type[T]], Type[T]]:
     ...
 
@@ -142,6 +150,8 @@ def serde(
     tagging: Tagging = DefaultTagging,
     type_check: TypeCheck = NoCheck,
     serialize_class_var: bool = False,
+    class_serializer: Optional[ClassSerializer] = None,
+    class_deserializer: Optional[ClassDeserializer] = None,
 ) -> Any:
     """
     serde decorator. Keyword arguments are passed in `serialize` and `deserialize`.
@@ -160,6 +170,7 @@ def serde(
             tagging=tagging,
             type_check=type_check,
             serialize_class_var=serialize_class_var,
+            class_serializer=class_serializer,
         )
         deserialize(
             cls,
@@ -171,6 +182,7 @@ def serde(
             tagging=tagging,
             type_check=type_check,
             serialize_class_var=serialize_class_var,
+            class_deserializer=class_deserializer,
         )
         return cls
 

--- a/serde/core.py
+++ b/serde/core.py
@@ -10,6 +10,7 @@ import sys
 import re
 from dataclasses import dataclass
 from typing import (
+    Protocol,
     Any,
     Callable,
     Dict,
@@ -1018,3 +1019,41 @@ def has_default_factory(field: Field[Any]) -> bool:
     True
     """
     return not isinstance(field.default_factory, dataclasses._MISSING_TYPE)
+
+
+class ClassSerializer(Protocol):
+    """
+    Interface for custom class serializer.
+
+    This protocol is intended to be used for custom class serializer.
+
+    >>> from datetime import datetime
+    >>> from serde import serde
+    >>> from plum import dispatch
+    >>> class MySerializer(ClassSerializer):
+    ...     @dispatch
+    ...     def serialize(self, value: datetime) -> str:
+    ...         return value.strftime("%d/%m/%y")
+    """
+
+    def serialize(self, value: Any) -> Any:
+        pass
+
+
+class ClassDeserializer(Protocol):
+    """
+    Interface for custom class deserializer.
+
+    This protocol is intended to be used for custom class deserializer.
+
+    >>> from datetime import datetime
+    >>> from serde import serde
+    >>> from plum import dispatch
+    >>> class MyDeserializer(ClassDeserializer):
+    ...     @dispatch
+    ...     def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+    ...         return datetime.strptime(value, "%d/%m/%y")
+    """
+
+    def deserialize(self, cls: Any, value: Any) -> Any:
+        pass

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -2,24 +2,24 @@
 Tests for custom serializer/deserializer.
 """
 from datetime import datetime
-from typing import List, Optional, Union, Set
+from typing import List, Optional, Any, Dict, Type, Union
+from plum import dispatch
 
 import pytest
 
 from serde import (
     SerdeError,
-    SerdeSkip,
-    default_deserializer,
-    default_serializer,
     field,
     from_tuple,
     serde,
     to_tuple,
+    ClassSerializer,
+    ClassDeserializer,
 )
 from serde.json import from_json, to_json
 
 
-def test_custom_field_serializer():
+def test_custom_field_serializer() -> None:
     @serde
     class Foo:
         a: datetime
@@ -42,8 +42,8 @@ def test_custom_field_serializer():
     assert f == from_tuple(Foo, to_tuple(f))
 
 
-def test_raise_error():
-    def raise_exception(_):
+def test_raise_error() -> None:
+    def raise_exception(_: Any) -> None:
         raise Exception()
 
     @serde
@@ -51,14 +51,14 @@ def test_raise_error():
         i: int = field(serializer=raise_exception, deserializer=raise_exception)
 
     f = Foo(10)
-    with pytest.raises(Exception):
+    with pytest.raises(SerdeError):
         to_json(f)
 
-    with pytest.raises(Exception):
+    with pytest.raises(SerdeError):
         from_json(Foo, '{"i": 10}')
 
 
-def test_wrong_signature():
+def test_wrong_signature() -> None:
     @serde
     class Foo:
         i: int = field(serializer=lambda: "10", deserializer=lambda: 10)
@@ -71,73 +71,141 @@ def test_wrong_signature():
         from_json(Foo, '{"i": 10}')
 
 
-def test_custom_class_serializer():
-    def serializer(cls, o):
-        if cls is datetime:
-            return o.strftime("%d/%m/%y")
-        else:
-            raise SerdeSkip()
+def test_custom_class_serializer() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
 
-    def deserializer(cls, o):
-        if cls is datetime:
-            return datetime.strptime(o, "%d/%m/%y")
-        else:
-            raise SerdeSkip()
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
 
-    @serde(serializer=serializer, deserializer=deserializer)
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+    class Bar:
+        e: datetime
+        f: List[datetime]
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
     class Foo:
-        a: int
-        b: datetime
-        c: datetime
-        d: Optional[str] = None
-        e: Union[str, int] = 10
-        f: List[int] = field(default_factory=list)
-        g: Set[int] = field(default_factory=set)
+        a: datetime
+        b: List[datetime]
+        c: Dict[str, datetime]
+        d: Bar
 
     dt = datetime(2021, 1, 1, 0, 0, 0)
-    f = Foo(10, dt, dt, f=[1, 2, 3], g={4, 5, 6})
+    f = Foo(dt, [dt], {"k": dt}, Bar(dt, [dt]))
 
-    assert (
-        to_json(f)
-        == '{"a":10,"b":"01/01/21","c":"01/01/21","d":null,"e":10,"f":[1,2,3],"g":[4,5,6]}'
+    s = (
+        '{"a":"01/01/21","b":["01/01/21"],"c":{"k":"01/01/21"},'
+        '"d":{"e":"01/01/21","f":["01/01/21"]}}'
     )
-    assert f == from_json(Foo, to_json(f))
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
 
-    assert to_tuple(f) == (10, "01/01/21", "01/01/21", None, 10, [1, 2, 3], {4, 5, 6})
-    assert f == from_tuple(Foo, to_tuple(f))
+    t = ("01/01/21", ["01/01/21"], {"k": "01/01/21"}, ("01/01/21", ["01/01/21"]))
+    assert t == to_tuple(f)
+    assert f == from_tuple(Foo, t)
 
-    def fallback(_, __):
-        raise SerdeSkip()
 
-    @serde(serializer=fallback, deserializer=fallback)
+def test_custom_class_serializer_dataclass() -> None:
+    @serde
+    class Bar:
+        v: int
+
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: Bar) -> str:
+            return str(value.v)
+
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[Bar], value: Any) -> Bar:
+            return Bar(int(value))
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
     class Foo:
-        a: Optional[str]
-        b: str
+        bar: Bar
 
-    f = Foo("foo", "bar")
-    assert to_json(f) == '{"a":"foo","b":"bar"}'
-    assert f == from_json(Foo, '{"a":"foo","b":"bar"}')
-    assert Foo(None, "bar") == from_json(Foo, '{"b":"bar"}')
-    with pytest.raises(Exception):
-        assert Foo(None, "bar") == from_json(Foo, "{}")
-    with pytest.raises(Exception):
-        assert Foo("foo", "bar") == from_json(Foo, '{"a": "foo"}')
+    f = Foo(Bar(10))
+
+    s = '{"bar":"10"}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
 
 
-def test_field_serialize_override_class_serializer():
-    def serializer(cls, o):
-        if cls is datetime:
-            return o.strftime("%d/%m/%y")
-        else:
-            raise SerdeSkip()
+def test_custom_serializer_with_field_attributes() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
 
-    def deserializer(cls, o):
-        if cls is datetime:
-            return datetime.strptime(o, "%d/%m/%y")
-        else:
-            raise SerdeSkip()
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
 
-    @serde(serializer=serializer, deserializer=deserializer)
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+    class Foo:
+        # TODO This does not work as expected
+        # a: Optional[datetime] = field(
+        #    serializer=lambda x: x.strftime("%d/%m/%y"),
+        #    deserializer=lambda x: datetime.strptime(x, "%d/%m/%y"),
+        #    skip=True,
+        # )
+        b: Optional[datetime] = field(skip_if_false=True)
+        c: Optional[datetime] = field(skip_if_false=True)
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(dt, None)
+    s = '{"b":"01/01/21"}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
+
+
+def test_custom_serializer_with_class_attributes() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
+
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
+
+    @serde(
+        class_serializer=MySerializer(),
+        class_deserializer=MyDeserializer(),
+        rename_all="capitalcase",
+    )
+    class Foo:
+        a: datetime
+        b: datetime = field(
+            serializer=lambda x: x.strftime("%d/%m/%y"),
+            deserializer=lambda x: datetime.strptime(x, "%d/%m/%y"),
+        )
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(dt, dt)
+    s = '{"A":"01/01/21","B":"01/01/21"}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
+
+
+def test_field_serialize_override_class_serializer() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
+
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
     class Foo:
         a: int
         b: datetime
@@ -149,37 +217,65 @@ def test_field_serialize_override_class_serializer():
     dt = datetime(2021, 1, 1, 0, 0, 0)
     f = Foo(10, dt, dt)
 
-    assert to_json(f) == '{"a":10,"b":"01/01/21","c":"21.01.01"}'
-    assert f == from_json(Foo, to_json(f))
+    s = '{"a":10,"b":"01/01/21","c":"21.01.01"}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
 
-    assert to_tuple(f) == (10, "01/01/21", "21.01.01")
-    assert f == from_tuple(Foo, to_tuple(f))
+    t = (10, "01/01/21", "21.01.01")
+    assert t == to_tuple(f)
+    assert f == from_tuple(Foo, t)
 
 
-def test_override_by_default_serializer():
-    def serializer(cls, o):
-        if cls is datetime:
-            return o.strftime("%d/%m/%y")
-        else:
-            raise SerdeSkip()
+def test_custom_serializer_union() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
 
-    def deserializer(cls, o):
-        if cls is datetime:
-            return datetime.strptime(o, "%d/%m/%y")
-        else:
-            raise SerdeSkip()
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
 
-    @serde(serializer=serializer, deserializer=deserializer)
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+    class Bar:
+        v: datetime
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+    class Baz:
+        v: datetime
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
     class Foo:
-        a: int
-        b: datetime
-        c: datetime = field(serializer=default_serializer, deserializer=default_deserializer)
+        v: Union[Bar, Baz]
 
     dt = datetime(2021, 1, 1, 0, 0, 0)
-    f = Foo(10, dt, dt)
+    f = Foo(Baz(dt))
+    s = '{"v":{"Baz":{"v":"01/01/21"}}}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)
 
-    assert to_json(f) == '{"a":10,"b":"01/01/21","c":"2021-01-01T00:00:00"}'
-    assert f == from_json(Foo, to_json(f))
 
-    assert to_tuple(f) == (10, "01/01/21", datetime(2021, 1, 1, 0, 0))
-    assert f == from_tuple(Foo, to_tuple(f))
+def test_custom_class_serializer_optional() -> None:
+    class MySerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: datetime) -> str:
+            return value.strftime("%d/%m/%y")
+
+    class MyDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: Type[datetime], value: Any) -> datetime:
+            return datetime.strptime(value, "%d/%m/%y")
+
+    @serde(class_serializer=MySerializer(), class_deserializer=MyDeserializer())
+    class Foo:
+        a: datetime
+        b: Optional[datetime]
+        c: Optional[datetime]
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(dt, dt, None)
+
+    s = '{"a":"01/01/21","b":"01/01/21","c":null}'
+    assert s == to_json(f)
+    assert f == from_json(Foo, s)

--- a/tests/test_legacy_custom.py
+++ b/tests/test_legacy_custom.py
@@ -1,0 +1,132 @@
+"""
+Tests for custom serializer/deserializer.
+"""
+from datetime import datetime
+from typing import List, Optional, Union, Set
+
+import pytest
+
+from serde import (
+    SerdeSkip,
+    default_deserializer,
+    default_serializer,
+    field,
+    from_tuple,
+    serde,
+    to_tuple,
+)
+from serde.json import from_json, to_json
+
+
+def test_legacy_custom_class_serializer():
+    def serializer(cls, o):
+        if cls is datetime:
+            return o.strftime("%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    def deserializer(cls, o):
+        if cls is datetime:
+            return datetime.strptime(o, "%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    @serde(serializer=serializer, deserializer=deserializer)
+    class Foo:
+        a: int
+        b: datetime
+        c: datetime
+        d: Optional[str] = None
+        e: Union[str, int] = 10
+        f: List[int] = field(default_factory=list)
+        g: Set[int] = field(default_factory=set)
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(10, dt, dt, f=[1, 2, 3], g={4, 5, 6})
+
+    assert (
+        to_json(f)
+        == '{"a":10,"b":"01/01/21","c":"01/01/21","d":null,"e":10,"f":[1,2,3],"g":[4,5,6]}'
+    )
+    assert f == from_json(Foo, to_json(f))
+
+    assert to_tuple(f) == (10, "01/01/21", "01/01/21", None, 10, [1, 2, 3], {4, 5, 6})
+    assert f == from_tuple(Foo, to_tuple(f))
+
+    def fallback(_, __):
+        raise SerdeSkip()
+
+    @serde(serializer=fallback, deserializer=fallback)
+    class Foo:
+        a: Optional[str]
+        b: str
+
+    f = Foo("foo", "bar")
+    assert to_json(f) == '{"a":"foo","b":"bar"}'
+    assert f == from_json(Foo, '{"a":"foo","b":"bar"}')
+    assert Foo(None, "bar") == from_json(Foo, '{"b":"bar"}')
+    with pytest.raises(Exception):
+        assert Foo(None, "bar") == from_json(Foo, "{}")
+    with pytest.raises(Exception):
+        assert Foo("foo", "bar") == from_json(Foo, '{"a": "foo"}')
+
+
+def test_field_serialize_override_legacy_class_serializer():
+    def serializer(cls, o):
+        if cls is datetime:
+            return o.strftime("%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    def deserializer(cls, o):
+        if cls is datetime:
+            return datetime.strptime(o, "%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    @serde(serializer=serializer, deserializer=deserializer)
+    class Foo:
+        a: int
+        b: datetime
+        c: datetime = field(
+            serializer=lambda x: x.strftime("%y.%m.%d"),
+            deserializer=lambda x: datetime.strptime(x, "%y.%m.%d"),
+        )
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(10, dt, dt)
+
+    assert to_json(f) == '{"a":10,"b":"01/01/21","c":"21.01.01"}'
+    assert f == from_json(Foo, to_json(f))
+
+    assert to_tuple(f) == (10, "01/01/21", "21.01.01")
+    assert f == from_tuple(Foo, to_tuple(f))
+
+
+def test_override_by_default_serializer():
+    def serializer(cls, o):
+        if cls is datetime:
+            return o.strftime("%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    def deserializer(cls, o):
+        if cls is datetime:
+            return datetime.strptime(o, "%d/%m/%y")
+        else:
+            raise SerdeSkip()
+
+    @serde(serializer=serializer, deserializer=deserializer)
+    class Foo:
+        a: int
+        b: datetime
+        c: datetime = field(serializer=default_serializer, deserializer=default_deserializer)
+
+    dt = datetime(2021, 1, 1, 0, 0, 0)
+    f = Foo(10, dt, dt)
+
+    assert to_json(f) == '{"a":10,"b":"01/01/21","c":"2021-01-01T00:00:00"}'
+    assert f == from_json(Foo, to_json(f))
+
+    assert to_tuple(f) == (10, "01/01/21", datetime(2021, 1, 1, 0, 0))
+    assert f == from_tuple(Foo, to_tuple(f))


### PR DESCRIPTION
Class custom (de)serializer depends on a python library plum https://github.com/beartype/plum

plum allows multiple method overloading like C++. With plum, you can write robust custom (de)serializer in a quite neat way.

Closes #456 #422 #418 #404 #261