### PR TITLE
Fix type error from field with attributes

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -113,3 +113,6 @@ print(from_json(Foo, s))
 ```
 
 That's it! pyserde offers many more features. If you're interested, please read the rest of the documentation.
+
+> **NOTE:** which type checker should be used?
+> pyserde depends on [PEP681 dataclass_transform](https://peps.python.org/pep-0681/). [mypy](https://github.com/python/mypy) does not fully support dataclass_transform as of Jan. 2024. [pyright](https://github.com/microsoft/pyright) is recommended for codebase using pyserde.

--- a/examples/field_order.py
+++ b/examples/field_order.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from serde import serde, field
+
+
+@serde
+@dataclass
+class Foo:
+    id: int = field(rename="ID")  # Field with attributes can be defined before other fields
+    # thanks to dataclass_transform field_specifiers
+    # https://peps.python.org/pep-0681/#the-dataclass-transform-decorator
+    # NOTE: you still get error with mypy as of mypy v1.8.0
+    comments: str
+
+
+if __name__ == "__main__":
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ strict = true
 ignore_missing_imports = true
 exclude = [
   "serde/numpy.py",
+  "examples/alias.py",
+  "examples/field_order.py",
   "bench",
   "tests"
 ]

--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -131,7 +131,7 @@ def serde(
     ...
 
 
-@dataclass_transform()  # type: ignore
+@dataclass_transform(field_specifiers=(field,))  # type: ignore
 def serde(
     _cls: Any = None,
     rename_all: Optional[str] = None,


### PR DESCRIPTION
This commit fixes pyright type error from field with attributes. You still get type error with mypy v1.8.0 as mypy still does not fully support dataclass_transform
```python
from dataclasses import dataclass
from serde import serde, field

@serde
@dataclass
class Foo:
    id: int = field(rename="ID")
    comments: str
```

Closes #457 