### PR TITLE
prefer `is_bearable` to `isinstance`

### DIFF
--- a/serde/se.py
+++ b/serde/se.py
@@ -21,6 +21,7 @@ from beartype.typing import (
     Type,
     Union,
 )
+from beartype.door import is_bearable
 
 import jinja2
 from typing_extensions import dataclass_transform
@@ -370,13 +371,13 @@ def to_obj(
             return serializable_to_obj(o)
         if is_serializable(o):
             return serializable_to_obj(o)
-        elif isinstance(o, list):
+        elif is_bearable(o, list):
             return [thisfunc(e) for e in o]
-        elif isinstance(o, tuple):
+        elif is_bearable(o, tuple):
             return tuple(thisfunc(e) for e in o)
-        elif isinstance(o, set):
+        elif is_bearable(o, set):
             return [thisfunc(e) for e in o]
-        elif isinstance(o, dict):
+        elif is_bearable(o, dict):
             return {k: thisfunc(v) for k, v in o.items()}
         elif is_str_serializable_instance(o):
             return str(o)
@@ -766,7 +767,7 @@ coerce_object(int, foo[2]),)"
             res = f"{arg.varname} if reuse_instances else {arg.varname}.isoformat()"
         elif is_none(arg.type):
             res = "None"
-        elif is_any(arg.type) or isinstance(arg.type, TypeVar):
+        elif is_any(arg.type) or is_bearable(arg.type, TypeVar):
             res = f"to_obj({arg.varname}, True, False, False, c=typing.Any)"
         elif is_generic(arg.type):
             origin = get_origin(arg.type)


### PR DESCRIPTION
Ran into an issue with parametrized generics not being supported by `isinstance`. Since you're already relying on beartype, I've found it _much_ easier to strictly rely on `is_bearable` to do dispatch, rather than `isinstance`. Stuff just behaves like I expect it to. 

Line 389 in `se.py` was raising a `SerdeError: isinstance() argument 2 cannot be a parametrized generic`. 

For more on the DOOR API see [here](https://beartype.readthedocs.io/en/latest/api_door/#door-procedures), with `is_bearable` specifically documented [here](https://beartype.readthedocs.io/en/latest/api_door/#beartype.door.is_bearable) As it mentions there, this is designed to replace `isinstance` by being a strict superset: 

> [is_bearable()](https://beartype.readthedocs.io/en/latest/api_door/#beartype.door.is_bearable) is a strict superset of the [isinstance()](https://docs.python.org/3/library/functions.html#isinstance) builtin. [is_bearable()](https://beartype.readthedocs.io/en/latest/api_door/#beartype.door.is_bearable) can thus be safely called wherever [isinstance()](https://docs.python.org/3/library/functions.html#isinstance) is called with the same exact parameters in the same exact order: