### PR TITLE
Raises SerdeError when type validation fails

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -11,8 +11,8 @@ import dataclasses
 import functools
 import typing
 import jinja2
-import beartype
 from collections.abc import Callable, Sequence, Iterable
+from beartype import beartype, BeartypeConf
 from beartype.roar import BeartypeCallHintParamViolation
 from dataclasses import dataclass, is_dataclass
 from typing import overload, TypeVar, Generic, Any, Optional, Union, Literal
@@ -223,7 +223,8 @@ def deserialize(
             dataclass(cls)
 
         if type_check.is_strict():
-            beartype.beartype(cls)
+            serde_beartype = beartype(conf=BeartypeConf(violation_type=SerdeError))
+            serde_beartype(cls)
 
         g: dict[str, Any] = {}
 

--- a/serde/se.py
+++ b/serde/se.py
@@ -10,11 +10,11 @@ import dataclasses
 import functools
 import typing
 import itertools
-import beartype
 import jinja2
 from dataclasses import dataclass, is_dataclass
 from typing import TypeVar, Literal, Generic, Optional, Any, Union
 from collections.abc import Callable, Iterable, Iterator
+from beartype import beartype, BeartypeConf
 from beartype.door import is_bearable
 from typing_extensions import dataclass_transform
 
@@ -198,7 +198,8 @@ def serialize(
             dataclass(cls)
 
         if type_check.is_strict():
-            beartype.beartype(cls)
+            serde_beartype = beartype(conf=BeartypeConf(violation_type=SerdeError))
+            serde_beartype(cls)
 
         g: dict[str, Any] = {}
 

--- a/tests/test_beartype.py
+++ b/tests/test_beartype.py
@@ -1,0 +1,26 @@
+import pytest
+from beartype import beartype
+from beartype.roar import BeartypeCallHintParamViolation
+from dataclasses import dataclass
+from serde import serde, SerdeError
+
+
+def test_raises_serde_error_instead_of_beartype_error() -> None:
+    @serde
+    class Foo:
+        v: int
+
+    with pytest.raises(SerdeError):
+        Foo("foo")  # type: ignore
+
+
+def test_raises_beartype_error_if_beartype_decorated() -> None:
+    # If a class already has beartype, pyserde cannot set custom validation error.
+    @serde
+    @beartype
+    @dataclass
+    class Foo:
+        v: int
+
+    with pytest.raises(BeartypeCallHintParamViolation):
+        Foo("foo")  # type: ignore


### PR DESCRIPTION
pyserde uses beartype v0.17 new feature to customize exception for type validation failure.

One caveat is when class already implements beartype decorator before serde as below, pyserde cannot set custom exception. In this case, beartype's exception is raised.

```python
@serde
@beartype
@dataclass
class Foo:
    ...
```