### PR TITLE
feat: add support for SQLAlchemy dataclass-mapped tables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           cache: poetry
           cache-dependency-path: pyproject.toml
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --extras sqlalchemy
       - name: Check coverage
         run: make coverage
       - name: Upload coverage report to codecov.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,14 @@ jobs:
         run: |
           make examples
         if: matrix.python-version == '3.12'
+      - name: Run tests (sqlalchemy)
+        run: |
+          poetry install --extras sqlalchemy
+          make test
+      - name: Run examples (sqlalchemy)
+        run: |
+          make examples
+        if: matrix.python-version == '3.12'
 
   check_formatting:
     name: Check formatting

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Foo(i=10, s='foo', f=100.0, b=True)
         - [`ipaddress`](https://docs.python.org/3/library/ipaddress.html)
     - PyPI library
         - [`numpy`](https://github.com/numpy/numpy) types
-        - [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping
+        - [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping (experimental)
 - [Class Attributes](https://github.com/yukinarit/pyserde/blob/main/docs/en/class-attributes.md)
 - [Field Attributes](https://github.com/yukinarit/pyserde/blob/main/docs/en/field-attributes.md)
 - [Decorators](https://github.com/yukinarit/pyserde/blob/main/docs/en/decorators.md)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Foo(i=10, s='foo', f=100.0, b=True)
         - [`ipaddress`](https://docs.python.org/3/library/ipaddress.html)
     - PyPI library
         - [`numpy`](https://github.com/numpy/numpy) types
+        - [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping
 - [Class Attributes](https://github.com/yukinarit/pyserde/blob/main/docs/en/class-attributes.md)
 - [Field Attributes](https://github.com/yukinarit/pyserde/blob/main/docs/en/field-attributes.md)
 - [Decorators](https://github.com/yukinarit/pyserde/blob/main/docs/en/decorators.md)

--- a/docs/en/types.md
+++ b/docs/en/types.md
@@ -24,7 +24,7 @@ Here is the list of the supported types. See the simple example for each type in
     * [`ipaddress`](https://docs.python.org/3/library/ipaddress.html) [^22]
 * PyPI library
     * [`numpy`](https://github.com/numpy/numpy) types [^23]
-    * [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping [^24]
+    * [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping (experimental) [^24]
 
 You can write pretty complex class like this:
 ```python
@@ -88,6 +88,11 @@ npfoo = NPFoo(
 >>> from_json(NPFoo, to_json(npfoo))
 NPFoo(i=1, j=2, f=3.0, g=4.0, h=False, u=array([1, 2]), v=array([3, 4]), w=array([1, 2], dtype=int32), x=array([3, 4]), y=array([5., 6.], dtype=float32), z=array([7., 8.]))
 ```
+
+## SQLAlchemy Declarative Dataclass Mapping (experimental)
+While experimental support for SQLAlchemy Declarative Dataclass Mapping integration has been added, certain features such as `@serde(type_check=strict)` and `serde.field()` are not currently supported.
+
+It's recommended to exercise caution when relying on experimental features in production environments. It's also advisable to thoroughly test your code and be aware of potential limitations or unexpected behavior.
 
 ## Needs a new type support?
 

--- a/docs/en/types.md
+++ b/docs/en/types.md
@@ -24,6 +24,7 @@ Here is the list of the supported types. See the simple example for each type in
     * [`ipaddress`](https://docs.python.org/3/library/ipaddress.html) [^22]
 * PyPI library
     * [`numpy`](https://github.com/numpy/numpy) types [^23]
+    * [`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy) Declarative Dataclass Mapping [^24]
 
 You can write pretty complex class like this:
 ```python
@@ -135,3 +136,5 @@ If you need to use a type which is currently not supported in the standard libra
 [^22]: See [examples/type_ipaddress.py](https://github.com/yukinarit/pyserde/blob/main/examples/type_ipaddress.py)
 
 [^23]: See [examples/type_numpy.py](https://github.com/yukinarit/pyserde/blob/main/examples/type_numpy.py)
+
+[^24]: See [examples/type_sqlalchemy.py](https://github.com/yukinarit/pyserde/blob/main/examples/type_sqlalchemy.py)

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -115,6 +115,13 @@ def run_all() -> None:
     run(type_uuid)
     run(type_numpy)
 
+    try:
+        import type_sqlalchemy
+
+        run(type_sqlalchemy)
+    except ImportError:
+        pass
+
 
 def run(module: typing.Any) -> None:
     print("-----------------")

--- a/examples/type_sqlalchemy.py
+++ b/examples/type_sqlalchemy.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from sqlalchemy import Text, JSON, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Mapped, mapped_column, relationship
+
+from serde import serde
+from serde.json import from_json, to_json
+
+
+class Base(MappedAsDataclass, DeclarativeBase):  # type: ignore[misc]
+    pass
+
+
+@serde
+class Project(Base):
+    __tablename__ = "projects"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+
+
+@serde
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    fullname: Mapped[str] = mapped_column(Text, nullable=False)
+    nickname: Mapped[Optional[str]] = mapped_column(Text)
+    attributes: Mapped[Optional[dict[str, str]]] = mapped_column(JSON)
+    projects: Mapped[list[Project]] = relationship(backref="owner")
+
+
+def main() -> None:
+    user = User(
+        id=1,
+        name="john",
+        fullname="John Doe",
+        nickname=None,
+        attributes={"color": "green"},
+        projects=[Project(id=1, name="Dummy", owner_id=1)],
+    )
+    print(f"Into Json: {to_json(user)}")
+
+    s = """{
+        "id": 1,
+        "name": "john",
+        "fullname": "John Doe",
+        "nickname": null,
+        "attributes": {
+            "color": "green"
+        },
+        "projects": [
+            {
+                "id": 1,
+                "name": "Dummy",
+                "owner_id": 1
+            }
+        ]
+    }"""
+    print(f"From Json: {from_json(User, s)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ pytest-xdist = "^3.5.0"
 types-PyYAML = "^6.0.9"
 msgpack-types = "^0.2"
 envclasses = "^0.3.1"
-sqlalchemy = ">2"
 
 [tool.poetry.extras]
 msgpack = ["msgpack"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ pytest-xdist = "^3.5.0"
 types-PyYAML = "^6.0.9"
 msgpack-types = "^0.2"
 envclasses = "^0.3.1"
+sqlalchemy = ">2"
 
 [tool.poetry.extras]
 msgpack = ["msgpack"]
@@ -120,6 +121,7 @@ exclude = [
   "tests/test_literal.py",
   "tests/test_numpy.py",
   "tests/test_union.py",
+  "tests/test_sqlalchemy.py",
   "serde/__init__.py"
 ]
 pythonVersion = "3.12"
@@ -140,6 +142,7 @@ exclude = [
   "tests/test_literal.py",
   "tests/test_numpy.py",
   "tests/test_union.py",
+  "tests/test_sqlalchemy.py",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ numpy = [
 orjson = { version = "*", markers = "extra == 'orjson' or extra == 'all'", optional = true }
 plum-dispatch = ">=2,<2.3"
 beartype = ">=0.18.4"
+sqlalchemy = { version = ">2", markers = "extra == 'sqlalchemy' or extra == 'all'", optional = true }
 
 [tool.poetry.dev-dependencies]
 pyyaml = "*"
@@ -73,7 +74,8 @@ numpy = ["numpy"]
 toml = ["tomli", "tomli-w"]
 yaml = ["pyyaml"]
 orjson = ["orjson"]
-all = ["msgpack", "tomli", "tomli-w", "pyyaml", "numpy", "orjson"]
+sqlalchemy = ["sqlalchemy"]
+all = ["msgpack", "tomli", "tomli-w", "pyyaml", "numpy", "orjson", "sqlalchemy"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -22,6 +22,8 @@ from typing import TypeVar, Generic, Any, ClassVar, Optional, NewType, Union
 import typing_inspect
 from typing_extensions import TypeGuard
 
+from .sqlalchemy import is_sqlalchemy_inspectable
+
 
 def get_np_origin(tp: type[Any]) -> Optional[Any]:
     return None
@@ -257,6 +259,8 @@ def dataclass_fields(cls: type[Any]) -> Iterator[dataclasses.Field]:  # type: ig
         real_type = resolved_hints.get(f.name)
         if real_type is not None:
             f.type = real_type
+            if is_generic(real_type) and is_sqlalchemy_inspectable(cls):
+                f.type = get_args(real_type)[0]
 
     return iter(raw_fields)
 

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -698,6 +698,10 @@ def is_new_type_primitive(typ: Union[type[Any], NewType]) -> bool:
         return any(isinstance(typ, ty) for ty in PRIMITIVES)
 
 
+def has_generic_base(typ: Any) -> bool:
+    return Generic in getattr(typ, "__mro__", ()) or Generic in getattr(typ, "__bases__", ())
+
+
 def is_generic(typ: Any) -> bool:
     """
     Test if the type is derived from `typing.Generic`.
@@ -711,7 +715,7 @@ def is_generic(typ: Any) -> bool:
     False
     """
     origin = get_origin(typ)
-    return origin is not None and Generic in getattr(origin, "__bases__", ())
+    return origin is not None and has_generic_base(origin)
 
 
 def is_class_var(typ: type[Any]) -> bool:
@@ -796,7 +800,7 @@ def get_type_var_names(cls: type[Any]) -> Optional[list[str]]:
 
     type_arg_names: list[str] = []
     for base in bases:
-        type_arg_names.extend(arg.__name__ for arg in get_args(base))
+        type_arg_names.extend(arg.__name__ for arg in get_args(base) if hasattr(arg, "__name__"))
 
     return type_arg_names
 

--- a/serde/core.py
+++ b/serde/core.py
@@ -62,8 +62,6 @@ __all__ = [
     "union_func_name",
 ]
 
-from .sqlalchemy import is_sqlalchemy_inspectable, get_python_type
-
 logger = logging.getLogger("serde")
 
 
@@ -625,12 +623,8 @@ class Field(Generic[T]):
 
         kw_only = bool(f.kw_only) if sys.version_info >= (3, 10) else False
 
-        field_type = f.type
-        if is_generic(f.type) and is_sqlalchemy_inspectable(parent):
-            field_type = get_python_type(getattr(parent, f.name))
-
         return cls(
-            field_type,
+            f.type,
             f.name,
             default=f.default,
             default_factory=f.default_factory,

--- a/serde/core.py
+++ b/serde/core.py
@@ -62,6 +62,8 @@ __all__ = [
     "union_func_name",
 ]
 
+from .sqlalchemy import is_sqlalchemy_inspectable, get_python_type
+
 logger = logging.getLogger("serde")
 
 
@@ -623,8 +625,12 @@ class Field(Generic[T]):
 
         kw_only = bool(f.kw_only) if sys.version_info >= (3, 10) else False
 
+        field_type = f.type
+        if is_generic(f.type) and is_sqlalchemy_inspectable(parent):
+            field_type = get_python_type(getattr(parent, f.name))
+
         return cls(
-            f.type,
+            field_type,
             f.name,
             default=f.default,
             default_factory=f.default_factory,

--- a/serde/sqlalchemy.py
+++ b/serde/sqlalchemy.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 try:
     from sqlalchemy.inspection import inspect
@@ -11,15 +11,7 @@ try:
         except NoInspectionAvailable:
             return False
 
-    def get_python_type(subject: Any) -> Any:
-        if (obj := inspect(subject, raiseerr=False)) is None:
-            return None
-        return Optional[obj.type.python_type] if obj.nullable else obj.type.python_type
-
 except ImportError:
 
     def is_sqlalchemy_inspectable(subject: Any) -> bool:
         return False
-
-    def get_python_type(subject: Any) -> Any:
-        return None

--- a/serde/sqlalchemy.py
+++ b/serde/sqlalchemy.py
@@ -1,0 +1,25 @@
+from typing import Any, Optional
+
+try:
+    from sqlalchemy.inspection import inspect
+    from sqlalchemy.exc import NoInspectionAvailable
+
+    def is_sqlalchemy_inspectable(subject: Any) -> bool:
+        try:
+            inspect(subject)
+            return True
+        except NoInspectionAvailable:
+            return False
+
+    def get_python_type(subject: Any) -> Any:
+        if (obj := inspect(subject, raiseerr=False)) is None:
+            return None
+        return Optional[obj.type.python_type] if obj.nullable else obj.type.python_type
+
+except ImportError:
+
+    def is_sqlalchemy_inspectable(subject: Any) -> bool:
+        return False
+
+    def get_python_type(subject: Any) -> Any:
+        return None

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Optional
+
+import pytest
+from sqlalchemy import String
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+import serde
+from .common import (
+    opt_case,
+    opt_case_ids,
+    FormatFuncs,
+    format_dict,
+    format_tuple,
+    format_json,
+    format_msgpack,
+    format_yaml,
+    format_pickle,
+    format_toml,
+)
+
+log = logging.getLogger("test")
+
+serde.init(True)
+
+all_except_toml: FormatFuncs = (
+    format_dict + format_tuple + format_json + format_msgpack + format_yaml + format_pickle
+)
+
+
+@pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize("se,de", all_except_toml)
+def test_sqlalchemy_simple(se, de, opt):
+    log.info(f"Running test with se={se.__name__} de={de.__name__} opts={opt}")
+
+    class Base(MappedAsDataclass, DeclarativeBase):
+        pass
+
+    @serde.serde(**opt)
+    class User(Base):
+        __tablename__ = "user"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        name: Mapped[str]
+        fullname: Mapped[str] = mapped_column(String(30))
+        nickname: Mapped[Optional[str]] = mapped_column(init=False)
+
+    user = User(1, "john", "John Doe")
+    assert user == de(User, se(user))
+
+
+@pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize("se,de", format_toml)
+def test_sqlalchemy_simple_toml(se, de, opt):
+    log.info(f"Running test with se={se.__name__} de={de.__name__} opts={opt}")
+
+    class Base(MappedAsDataclass, DeclarativeBase):
+        pass
+
+    @serde.serde(**opt)
+    class User(Base):
+        __tablename__ = "user"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        name: Mapped[str]
+        fullname: Mapped[str] = mapped_column(String(30))
+
+    user = User(1, "john", "John Doe")
+    assert user == de(User, se(user))

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -2,10 +2,6 @@ import logging
 from typing import Optional
 
 import pytest
-from sqlalchemy import String
-from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass
-from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import mapped_column
 
 import serde
 from .common import (
@@ -21,6 +17,9 @@ from .common import (
     format_toml,
 )
 
+sa = pytest.importorskip("sqlalchemy", "2.0.0")
+sa_orm = pytest.importorskip("sqlalchemy.orm")
+
 log = logging.getLogger("test")
 
 serde.init(True)
@@ -35,17 +34,17 @@ all_except_toml: FormatFuncs = (
 def test_sqlalchemy_simple(se, de, opt):
     log.info(f"Running test with se={se.__name__} de={de.__name__} opts={opt}")
 
-    class Base(MappedAsDataclass, DeclarativeBase):
+    class Base(sa_orm.MappedAsDataclass, sa_orm.DeclarativeBase):
         pass
 
     @serde.serde(**opt)
     class User(Base):
         __tablename__ = "user"
 
-        id: Mapped[int] = mapped_column(primary_key=True)
-        name: Mapped[str]
-        fullname: Mapped[str] = mapped_column(String(30))
-        nickname: Mapped[Optional[str]] = mapped_column(init=False)
+        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
+        name: sa_orm.Mapped[str]
+        fullname: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(30))
+        nickname: sa_orm.Mapped[Optional[str]] = sa_orm.mapped_column(init=False)
 
     user = User(1, "john", "John Doe")
     assert user == de(User, se(user))
@@ -56,16 +55,16 @@ def test_sqlalchemy_simple(se, de, opt):
 def test_sqlalchemy_simple_toml(se, de, opt):
     log.info(f"Running test with se={se.__name__} de={de.__name__} opts={opt}")
 
-    class Base(MappedAsDataclass, DeclarativeBase):
+    class Base(sa_orm.MappedAsDataclass, sa_orm.DeclarativeBase):
         pass
 
     @serde.serde(**opt)
     class User(Base):
         __tablename__ = "user"
 
-        id: Mapped[int] = mapped_column(primary_key=True)
-        name: Mapped[str]
-        fullname: Mapped[str] = mapped_column(String(30))
+        id: sa_orm.Mapped[int] = sa_orm.mapped_column(primary_key=True)
+        name: sa_orm.Mapped[str]
+        fullname: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(30))
 
     user = User(1, "john", "John Doe")
     assert user == de(User, se(user))


### PR DESCRIPTION
Resolves #517

This hopefully add support for SQLAlchemy dataclass-mapped tables without breaking anything else

The following code should run without errors:
```python
from typing import Optional

import sqlalchemy as sa
from sqlalchemy import String, create_engine, JSON
from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Session
from sqlalchemy.orm import Mapped
from sqlalchemy.orm import mapped_column

from serde import serde, from_dict
from serde.json import to_json


class Base(MappedAsDataclass, DeclarativeBase):
    pass


@serde
class User(Base):
    __tablename__ = "user"

    id: Mapped[int] = mapped_column(primary_key=True)
    name: Mapped[str]
    fullname: Mapped[str] = mapped_column(String(30))
    nickname: Mapped[Optional[str]]
    meta: Mapped[Optional[JSON]] = mapped_column(type_=JSON)


engine = create_engine("sqlite:///:memory:")
Base.metadata.create_all(engine)

user = from_dict(User, {"id": 1, "name": "john", "fullname": "John Doe"})
with Session(engine) as session:
    session.add(user)
    session.commit()

    user = session.scalar(sa.select(User))

to_json(user)
```