### PR TITLE
Improve error message for coercing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ select = [
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]
+ignore = ["B904"]
 line-length = 100
 
 [tool.ruff.lint.mccabe]

--- a/serde/core.py
+++ b/serde/core.py
@@ -937,8 +937,13 @@ coerce = TypeCheck(kind=TypeCheck.Kind.Coerce)
 strict = TypeCheck(kind=TypeCheck.Kind.Strict)
 
 
-def coerce_object(typ: type[Any], obj: Any) -> Any:
-    return typ(obj) if is_coercible(typ, obj) else obj
+def coerce_object(cls: str, field: str, typ: type[Any], obj: Any) -> Any:
+    try:
+        return typ(obj) if is_coercible(typ, obj) else obj
+    except Exception as e:
+        raise SerdeError(
+            f"failed to coerce the field {cls}.{field} value {obj} into {typename(typ)}: {e}"
+        )
 
 
 def is_coercible(typ: type[Any], obj: Any) -> bool:

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
-from typing import Union
-from serde.de import from_obj
+from typing import Union, Optional
+from serde.de import deserialize, from_obj, Renderer, DeField
 
 
 def test_from_obj() -> None:
@@ -23,3 +23,105 @@ def test_from_obj() -> None:
     dec = from_obj(list[Decimal], ("0.1", 0.1), False, False)
     assert isinstance(dec[0], Decimal) and dec[0] == Decimal("0.1")
     assert isinstance(dec[1], Decimal) and dec[1] == Decimal(0.1)
+
+
+kwargs = (
+    "maybe_generic=maybe_generic, maybe_generic_type_vars=maybe_generic_type_vars, "
+    + "variable_type_args=None, reuse_instances=reuse_instances"
+)
+
+
+def test_render_primitives() -> None:
+
+    rendered = Renderer("foo").render(DeField(int, "i", datavar="data"))
+    assert rendered == 'coerce_object("None", "i", int, data["i"])'
+
+    rendered = Renderer("foo").render(DeField(int, "int_field", datavar="data", case="camelcase"))
+    assert rendered == 'coerce_object("None", "int_field", int, data["intField"])'
+
+    rendered = Renderer("foo").render(DeField(int, "i", datavar="data", index=1, iterbased=True))
+    assert rendered == 'coerce_object("None", "i", int, data[1])'
+
+
+def test_render_list() -> None:
+    rendered = Renderer("foo").render(DeField(list[int], "l", datavar="data"))
+    assert rendered == '[coerce_object("None", "v", int, v) for v in data["l"]]'
+
+    rendered = Renderer("foo").render(DeField(list[list[int]], "l", datavar="data"))
+    assert rendered == '[[coerce_object("None", "v", int, v) for v in v] for v in data["l"]]'
+
+
+def test_render_tuple() -> None:
+    @deserialize
+    class Foo:
+        pass
+
+    rendered = Renderer("foo").render(DeField(tuple[str, int, list[int], Foo], "d", datavar="data"))
+    rendered_str = 'coerce_object("None", "data["d"][0]", str, data["d"][0])'
+    rendered_int = 'coerce_object("None", "data["d"][1]", int, data["d"][1])'
+    rendered_lst = '[coerce_object("None", "v", int, v) for v in data["d"][2]]'
+    rendered_foo = f"Foo.__serde__.funcs['foo'](data=data[\"d\"][3], {kwargs})"
+    assert rendered == f"({rendered_str}, {rendered_int}, {rendered_lst}, {rendered_foo},)"
+
+    field = DeField(tuple[str, int, list[int], Foo], "d", datavar="data", index=0, iterbased=True)
+    rendered = Renderer("foo").render(field)
+    rendered_str = 'coerce_object("None", "data[0][0]", str, data[0][0])'
+    rendered_int = 'coerce_object("None", "data[0][1]", int, data[0][1])'
+    rendered_lst = '[coerce_object("None", "v", int, v) for v in data[0][2]]'
+    rendered_foo = f"Foo.__serde__.funcs['foo'](data=data[0][3], {kwargs})"
+    assert rendered == f"({rendered_str}, {rendered_int}, {rendered_lst}, {rendered_foo},)"
+
+
+def test_render_dict() -> None:
+    rendered = Renderer("foo").render(DeField(dict[str, int], "d", datavar="data"))
+    rendered_key = 'coerce_object("None", "k", str, k)'
+    rendered_val = 'coerce_object("None", "v", int, v)'
+    rendered_dct = f'{{{rendered_key}: {rendered_val} for k, v in data["d"].items()}}'
+    assert rendered == rendered_dct
+
+    @deserialize
+    class Foo:
+        pass
+
+    rendered = Renderer("foo").render(DeField(dict[Foo, list[Foo]], "f", datavar="data"))
+    rendered_key = f"Foo.__serde__.funcs['foo'](data=k, {kwargs})"
+    rendered_val = f"[Foo.__serde__.funcs['foo'](data=v, {kwargs}) for v in v]"
+
+    assert rendered == f'{{{rendered_key}: {rendered_val} for k, v in data["f"].items()}}'
+
+
+def test_render_set() -> None:
+    from typing import Set
+
+    rendered = Renderer("foo").render(DeField(Set[int], "l", datavar="data"))
+    assert rendered == 'set(coerce_object("None", "v", int, v) for v in data["l"])'
+
+    rendered = Renderer("foo").render(DeField(Set[Set[int]], "l", datavar="data"))
+    assert rendered == 'set(set(coerce_object("None", "v", int, v) for v in v) for v in data["l"])'
+
+
+def test_render_opt() -> None:
+    rendered = Renderer("foo").render(DeField(Optional[int], "o", datavar="data"))  # type: ignore
+    rendered_opt = (
+        '(coerce_object("None", "o", int, data["o"])) if data.get("o") is not None else None'
+    )
+    assert rendered == rendered_opt
+
+    rendered = Renderer("foo").render(DeField(Optional[list[int]], "o", datavar="data"))  # type: ignore
+    rendered_lst = '[coerce_object("None", "v", int, v) for v in data["o"]]'
+    rendered_opt = f'({rendered_lst}) if data.get("o") is not None else None'
+    assert rendered == rendered_opt
+
+    rendered = Renderer("foo").render(DeField(Optional[list[int]], "o", datavar="data"))  # type: ignore
+    rendered_lst = '[coerce_object("None", "v", int, v) for v in data["o"]]'
+    rendered_opt = f'({rendered_lst}) if data.get("o") is not None else None'
+    assert rendered == rendered_opt
+
+    @deserialize
+    class Foo:
+        a: Optional[list[int]]
+
+    rendered = Renderer("foo").render(DeField(Optional[Foo], "f", datavar="data"))  # type: ignore
+    rendered_foo = f"Foo.__serde__.funcs['foo'](data=data[\"f\"], {kwargs})"
+    rendered_opt = f'({rendered_foo}) if data.get("f") is not None else None'
+    assert rendered == rendered_opt


### PR DESCRIPTION
an example error message

```
failed to coerce the field Foo.bar value notint into int: invalid
literal for int() with base 10: 'notint'
```

Closes #423