### PR TITLE
type_check=disable should not implement beartype

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -274,7 +274,7 @@ def deserialize(
         for typ in iter_types(cls):
             # When we encounter a dataclass not marked with deserialize, then also generate
             # deserialize functions for it.
-            if is_dataclass_without_de(typ):
+            if is_dataclass_without_de(typ) and typ is not cls:
                 # We call deserialize and not wrap to make sure that we will use the default serde
                 # configuration for generating the deserialization function.
                 deserialize(typ)

--- a/serde/se.py
+++ b/serde/se.py
@@ -244,7 +244,7 @@ def serialize(
         for typ in iter_types(cls):
             # When we encounter a dataclass not marked with serialize, then also generate serialize
             # functions for it.
-            if is_dataclass_without_se(typ):
+            if is_dataclass_without_se(typ) and typ is not cls:
                 # We call serialize and not wrap to make sure that we will use the default serde
                 # configuration for generating the serialization function.
                 serialize(typ)


### PR DESCRIPTION
The issue was relevant only when `@serialize` or `@deserialize` used.

for #575