### PR TITLE
Fix InitVar with field attribute

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1126,3 +1126,12 @@ def test_frozen_dataclass() -> None:
 
     bar = Bar(a=10, b=20)
     assert bar == serde.from_dict(Bar, serde.to_dict(bar))
+
+
+def test_init_var_with_field_attribute() -> None:
+    @serde.serde
+    @dataclasses.dataclass
+    class Foo:
+        a: int = serde.field(skip=True)
+
+    assert serde.to_dict(Foo(10)) == {}


### PR DESCRIPTION
It seems should_impl_dataclass does not take InitVar into account, which causes field attributes not working properly. This fixes that issue.

Closes #581, #582