### PR TITLE
Add skip_none parameter

### DIFF
--- a/examples/runner.py
+++ b/examples/runner.py
@@ -132,5 +132,7 @@ def run(module: typing.Any) -> None:
 if __name__ == "__main__":
     try:
         run_all()
+        print("-----------------")
+        print("all tests passed successfully!")
     except Exception:
         sys.exit(1)

--- a/serde/json.py
+++ b/serde/json.py
@@ -56,6 +56,7 @@ def to_json(
     se: type[Serializer[str]] = JsonSerializer,
     reuse_instances: bool = False,
     convert_sets: bool = True,
+    skip_none: bool = False,
     **opts: Any,
 ) -> str:
     """
@@ -67,6 +68,9 @@ def to_json(
     By default, numpy objects are serialized, this behaviour can be customized with the `option`
     argument with [orjson](https://github.com/ijl/orjson#numpy), or the `default` argument with
     Python standard json library.
+
+    * `skip_none`: When set to True, any field in the class with a None value is excluded from the
+    serialized output. Defaults to False.
 
     If you want to use another json package, you can subclass `JsonSerializer` and implement
     your own logic.

--- a/serde/msgpack.py
+++ b/serde/msgpack.py
@@ -56,9 +56,12 @@ def to_msgpack(
     as a `msgpack.ExtType` If you supply other keyword arguments, they will be passed in
     `msgpack.packb` function.
 
-    If `named` is True, field names are preserved, namely the object is encoded as `dict` then
-    serialized into MsgPack.  If `named` is False, the object is encoded as `tuple` then serialized
-    into MsgPack. `named=False` will produces compact binary.
+    * `named`: If `named` is True, field names are preserved, namely the object is encoded as `dict`
+    then serialized into MsgPack.  If `named` is False, the object is encoded as `tuple` then
+    serialized into MsgPack. `named=False` will produces compact binary.
+
+    * `skip_none`: When set to True, any field in the class with a None value is excluded from the
+    serialized output. Defaults to False.
 
     If you want to use the other msgpack package, you can subclass `MsgPackSerializer` and
     implement your own logic.
@@ -107,6 +110,7 @@ def from_msgpack(
     de: type[Deserializer[bytes]] = MsgPackDeserializer,
     named: bool = True,
     ext_dict: Optional[dict[int, type[Any]]] = None,
+    skip_none: bool = False,
     **opts: Any,
 ) -> Any:
     """

--- a/serde/pickle.py
+++ b/serde/pickle.py
@@ -30,6 +30,7 @@ def to_pickle(
     se: type[Serializer[bytes]] = PickleSerializer,
     reuse_instances: bool = False,
     convert_sets: bool = True,
+    skip_none: bool = False,
     **opts: Any,
 ) -> bytes:
     return se.serialize(

--- a/serde/toml.py
+++ b/serde/toml.py
@@ -40,6 +40,7 @@ def to_toml(
     se: type[Serializer[str]] = TomlSerializer,
     reuse_instances: bool = False,
     convert_sets: bool = True,
+    skip_none: bool = True,
     **opts: Any,
 ) -> str:
     """
@@ -48,11 +49,21 @@ def to_toml(
     You can pass any serializable `obj`. If you supply keyword arguments other than `se`,
     they will be passed in `toml_w.dumps` function.
 
+    * `skip_none`: When set to True, any field in the class with a None value is excluded from the
+    serialized output. Defaults to True.
+
     If you want to use the other toml package, you can subclass `TomlSerializer` and implement
     your own logic.
     """
     return se.serialize(
-        to_dict(obj, c=cls, reuse_instances=reuse_instances, convert_sets=convert_sets), **opts
+        to_dict(
+            obj,
+            c=cls,
+            reuse_instances=reuse_instances,
+            convert_sets=convert_sets,
+            skip_none=skip_none,
+        ),
+        **opts,
     )
 
 

--- a/serde/yaml.py
+++ b/serde/yaml.py
@@ -32,6 +32,7 @@ def to_yaml(
     se: type[Serializer[str]] = YamlSerializer,
     reuse_instances: bool = False,
     convert_sets: bool = True,
+    skip_none: bool = False,
     **opts: Any,
 ) -> str:
     """
@@ -39,6 +40,9 @@ def to_yaml(
 
     You can pass any serializable `obj`. If you supply keyword arguments other than `se`,
     they will be passed in `yaml.safe_dump` function.
+
+    * `skip_none`: When set to True, any field in the class with a None value is excluded from the
+    serialized output. Defaults to False.
 
     If you want to use the other yaml package, you can subclass `YamlSerializer` and implement
     your own logic.

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -458,28 +458,6 @@ def test_msgpack_unnamed():
     assert p == serde.msgpack.from_msgpack(data.Pri, d, named=False)
 
 
-def test_toml():
-    @serde.serde
-    class Foo:
-        v: Optional[int]
-
-    f = Foo(10)
-    assert "v = 10\n" == serde.toml.to_toml(f)
-    assert f == serde.toml.from_toml(Foo, "v = 10\n")
-
-    # TODO: Should raise SerdeError
-    with pytest.raises(TypeError):
-        f = Foo(None)
-        serde.toml.to_toml(f)
-
-    @serde.serde
-    class Foo:
-        v: set[int]
-
-    f = Foo({1, 2, 3})
-    serde.toml.to_toml(f)
-
-
 @pytest.mark.parametrize("se,de", all_formats)
 def test_rename(se, de):
     @serde.serde

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,0 +1,56 @@
+from serde import serde
+from serde.toml import to_toml, from_toml
+from typing import Optional
+import pytest
+
+
+def toml_basics() -> None:
+    @serde
+    class Foo:
+        v: Optional[int]
+
+    f = Foo(10)
+    assert "v = 10\n" == to_toml(f)
+    assert f == from_toml(Foo, "v = 10\n")
+
+    @serde
+    class Bar:
+        v: set[int]
+
+    b = Bar({1, 2, 3})
+    to_toml(b)
+
+
+def test_skip_none() -> None:
+    @serde
+    class Foo:
+        a: int
+        b: Optional[int]
+
+    f = Foo(10, 100)
+    assert (
+        to_toml(f)
+        == """\
+a = 10
+b = 100
+"""
+    )
+
+    f = Foo(10, None)
+    assert (
+        to_toml(f)
+        == """\
+a = 10
+"""
+    )
+
+
+def test_skip_none_container_not_supported_yet() -> None:
+    @serde
+    class Foo:
+        a: int
+        b: list[Optional[int]]
+
+    f = Foo(10, [100, None])
+    with pytest.raises(TypeError):
+        to_toml(f)


### PR DESCRIPTION
The `skip_none` attribute is an optional feature originally implemented to prevent null values from appearing in TOML serialized outputs. When set to True, any field in the class with a None value is excluded from the serialized output, ensuring that TOML files (or other formats) remain clean and free from null entries.

Closes #421