### PR TITLE
Implement deny_unknown_fields class attribute

### DIFF
--- a/docs/en/class-attributes.md
+++ b/docs/en/class-attributes.md
@@ -163,3 +163,23 @@ class Foo:
 See [examples/class_var.py](https://github.com/yukinarit/pyserde/blob/main/examples/class_var.py) for complete example.
 
 [^1]: [dataclasses.fields](https://docs.python.org/3/library/dataclasses.html#dataclasses.fields)
+
+### **`deny_unknown_fields`**
+
+New in v0.22.0, the `deny_unknown_fields` option in the pyserde decorator allows you to enforce strict field validation during deserialization. When this option is enabled, any fields in the input data that are not defined in the target class will cause deserialization to fail with a `SerdeError`.
+
+Consider the following example:
+```python
+@serde(deny_unknown_fields=True)
+class Foo:
+    a: int
+    b: str
+```
+
+With `deny_unknown_fields=True`, attempting to deserialize data containing fields beyond those defined (a and b in this case) will raise an error. For instance:
+```
+from_json(Foo, '{"a": 10, "b": "foo", "c": 100.0, "d": true}')
+```
+This will raise a `SerdeError` since fields c and d are not recognized members of Foo.
+
+See [examples/deny_unknown_fields.py](https://github.com/yukinarit/pyserde/blob/main/examples/deny_unknown_fields.py) for complete example.

--- a/docs/ja/class-attributes.md
+++ b/docs/ja/class-attributes.md
@@ -178,6 +178,26 @@ class Foo:
     a: ClassVar[int] = 10
 ```
 
-完全な例については、[examples/class_var.py](https://github.com/yukinarit/pyserde/blob/main/examples/class_var.py) を参照してください。
+完全な例については、[examples/class_var.py](https://github.com/yukinarit/pyserde/blob/main/examples/class_var.py)を参照してください。
 
 [^1]: [dataclasses.fields](https://docs.python.org/3/library/dataclasses.html#dataclasses.fields)
+
+### **`deny_unknown_fields`**
+
+バージョン0.22.0で新規追加。 pyserdeデコレータの`deny_unknown_fields`オプションはデシリアライズ時のより厳格なフィールドチェックを制御できます。このオプションをTrueにするとデシリアライズ時に宣言されていないフィールドが見つかると`SerdeError`を投げることができます。
+
+以下の例を考えてください。
+```python
+@serde(deny_unknown_fields=True)
+class Foo:
+    a: int
+    b: str
+```
+
+`deny_unknown_fields=True`が指定されていると、 宣言されているフィールド(この場合aとb)以外がインプットにあると例外を投げます。例えば、
+```
+from_json(Foo, '{"a": 10, "b": "foo", "c": 100.0, "d": true}')
+```
+上記のコードはフィールドcとdという宣言されていないフィールドがあるためエラーとなります。
+
+完全な例については、[examples/deny_unknown_fields.py](https://github.com/yukinarit/pyserde/blob/main/examples/deny_unknown_fields.py)を参照してください。

--- a/examples/deny_unknown_fields.py
+++ b/examples/deny_unknown_fields.py
@@ -1,0 +1,20 @@
+from serde import serde, SerdeError
+from serde.json import from_json
+
+
+@serde(deny_unknown_fields=True)
+class Foo:
+    a: int
+    b: str
+
+
+def main() -> None:
+    try:
+        s = '{"a": 10, "b": "foo", "c": 100.0, "d": true}'
+        print(f"From Json: {from_json(Foo, s)}")
+    except SerdeError:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -35,6 +35,7 @@ def run_all() -> None:
     import pep681
     import plain_dataclass
     import plain_dataclass_class_attribute
+    import deny_unknown_fields
     import python_pickle
     import recursive
     import recursive_list
@@ -107,6 +108,7 @@ def run_all() -> None:
     run(class_var)
     run(plain_dataclass)
     run(plain_dataclass_class_attribute)
+    run(deny_unknown_fields)
     run(msg_pack)
     run(primitive_subclass)
     run(kw_only)
@@ -133,6 +135,6 @@ if __name__ == "__main__":
     try:
         run_all()
         print("-----------------")
-        print("all tests passed successfully!")
+        print("all examples completed successfully!")
     except Exception:
         sys.exit(1)

--- a/serde/__init__.py
+++ b/serde/__init__.py
@@ -124,6 +124,7 @@ def serde(
     serialize_class_var: bool = False,
     class_serializer: Optional[ClassSerializer] = None,
     class_deserializer: Optional[ClassDeserializer] = None,
+    deny_unknown_fields: bool = False,
 ) -> Type[T]: ...
 
 
@@ -140,6 +141,7 @@ def serde(
     serialize_class_var: bool = False,
     class_serializer: Optional[ClassSerializer] = None,
     class_deserializer: Optional[ClassDeserializer] = None,
+    deny_unknown_fields: bool = False,
 ) -> Callable[[type[T]], type[T]]: ...
 
 
@@ -156,6 +158,7 @@ def serde(
     serialize_class_var: bool = False,
     class_serializer: Optional[ClassSerializer] = None,
     class_deserializer: Optional[ClassDeserializer] = None,
+    deny_unknown_fields: bool = False,
 ) -> Any:
     """
     serde decorator. Keyword arguments are passed in `serialize` and `deserialize`.
@@ -187,6 +190,7 @@ def serde(
             type_check=type_check,
             serialize_class_var=serialize_class_var,
             class_deserializer=class_deserializer,
+            deny_unknown_fields=deny_unknown_fields,
         )
         return cls
 


### PR DESCRIPTION
Added a `deny_unknown_fields` feature for stricter deserialization, rejecting any unexpected or unrecognized fields during deserialization.

#596 