### PR TITLE
Fix flatten with default

### DIFF
--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -81,3 +81,37 @@ def test_flatten_not_supported(se: Any, de: Any) -> None:
         @serde
         class Foo:
             bar: list[Bar] = field(flatten=True)
+
+
+def test_flatten_default() -> None:
+    @serde
+    class Bar:
+        c: float = field(default=0.0)
+        d: bool = field(default=False)
+
+    @serde
+    class Foo:
+        a: int
+        b: str = field(default="foo")
+        bar: Bar = field(flatten=True, default_factory=Bar)
+
+    f = Foo(a=10, b="b", bar=Bar(c=100.0, d=True))
+    assert from_json(Foo, to_json(f)) == f
+
+    assert from_json(Foo, '{"a": 20}') == Foo(20, "foo", Bar())
+
+
+def test_flatten_default_alias() -> None:
+    @serde
+    class Bar:
+        a: float = field(default=0.0, alias=["aa"])  # type: ignore
+        b: bool = field(default=False, alias=["bb"])  # type: ignore
+
+    @serde
+    class Foo:
+        bar: Bar = field(flatten=True, default_factory=Bar)
+
+    f = Foo(bar=Bar(100.0, True))
+    assert from_json(Foo, to_json(f)) == f
+
+    assert from_json(Foo, '{"aa": 20.0, "bb": false}') == Foo(Bar(20.0, False))


### PR DESCRIPTION
When a field has both flatten and default attributes, pyserde did not render the code correctly. See #610 for more detailed explanation. This commit fixes that as well as the case with alias attribute. See also test_flatten.py.

Closes #610