### PR TITLE
Fix dict[str, Any] serialization

### DIFF
--- a/serde/se.py
+++ b/serde/se.py
@@ -381,8 +381,9 @@ def to_obj(
         elif is_bearable(o, dict):
             return {k: thisfunc(v) for k, v in o.items()}
         elif is_str_serializable_instance(o) or is_datetime_instance(o):
+            se_cls = o.__class__ if not c or c is Any else c
             return CACHE.serialize(
-                c or o.__class__,
+                se_cls,
                 o,
                 reuse_instances=reuse_instances,
                 convert_sets=convert_sets,


### PR DESCRIPTION
When a dict inside a class had values of type Any and the dict contained non-primitive types, pyserde would enter an infinite recusion.  See #617 for details.

The fix here causes non-primitive values to be serialized as strings when calling to_dict.  Arguably, this loses information, as a dict should be able to store the values without serializing them to strings first.  However, this same behavior exists when a dataclass variable is typed as Any and contains a non-primitive object (pyserde serializes it to a string):

```
import serde
import uuid
from typing import Any

@serde.serde
class A:
    a: Any

foo = A(uuid.UUID('05b69d9a-3783-46ea-a811-35fa4b72ddac'))
print(to_dict(a))  # {'a': '05b69d9a-3783-46ea-a811-35fa4b72ddac'}
```

Fixes #617