### PR TITLE
Support `numpy>2.0.0`

### DIFF
--- a/examples/type_numpy.py
+++ b/examples/type_numpy.py
@@ -11,7 +11,7 @@ class Foo:
     in_: numpy.int_
     inc: numpy.intc
     ui: numpy.uint
-    fl: numpy.float_
+    fl: numpy.float64
     st: numpy.str_
     nd: numpy.typing.NDArray[numpy.int_]
     ha: numpy.half
@@ -25,7 +25,7 @@ def main() -> None:
         in_=numpy.int_(42),
         inc=numpy.intc(42),
         ui=numpy.uint(42),
-        fl=numpy.float_(3.14),
+        fl=numpy.float64(3.14),
         st=numpy.str_("numpy str"),
         nd=numpy.array([1, 2, 3]),
         ha=numpy.half(3.14),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ tomli = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional
 tomli-w = { version = "*", markers = "extra == 'toml' or extra == 'all'", optional = true }
 pyyaml = { version = "*", markers = "extra == 'yaml' or extra == 'all'", optional = true }
 numpy = [
-  { version = ">1.21.0,<2.0.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.11' and (extra == 'numpy' or extra == 'all')", optional = true },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.12' and (extra == 'numpy' or extra == 'all')", optional = true },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.13' and (extra == 'numpy' or extra == 'all')", optional = true },
+  { version = ">1.21.0,<3.0.0", markers = "python_version ~= '3.9.0' and (extra == 'numpy' or extra == 'all')", optional = true },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.10' and (extra == 'numpy' or extra == 'all')", optional = true },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.11' and (extra == 'numpy' or extra == 'all')", optional = true },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.12' and (extra == 'numpy' or extra == 'all')", optional = true },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.13' and (extra == 'numpy' or extra == 'all')", optional = true },
 ]
 jaxtyping = { version = "<0.3.0", markers = "extra == 'jaxtyping' or extra == 'all'", optional = true }
 orjson = { version = "*", markers = "extra == 'orjson' or extra == 'all'", optional = true }
@@ -52,11 +52,11 @@ tomli = { version = "*", markers = "python_version <= '3.11.0'" }
 tomli-w = "*"
 msgpack = "*"
 numpy = [
-  { version = ">1.21.0,<2.0.0", markers = "python_version ~= '3.9.0'" },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.10'" },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.11'" },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.12'" },
-  { version = ">1.22.0,<2.0.0", markers = "python_version ~= '3.13'" },
+  { version = ">1.21.0,<3.0.0", markers = "python_version ~= '3.9.0'" },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.10'" },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.11'" },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.12'" },
+  { version = ">1.22.0,<3.0.0", markers = "python_version ~= '3.13'" },
 ]
 mypy = "==1.14.0"
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ select = [
   "F", # pyflakes
   "C", # flake8-comprehensions
   "B", # flake8-bugbear
+  "NPY201", # numpy2-deprecation
 ]
 ignore = ["B904"]
 line-length = 100

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -92,7 +92,6 @@ def test_numpy_simple(se, de, opt):
 
     @serde.serde(**opt)
     class NumpyJaxtyping:
-        float_: jaxtyping.Float[np.ndarray, "2 2"]  # noqa: F722
         float16: jaxtyping.Float16[np.ndarray, "2 2"]  # noqa: F722
         float32: jaxtyping.Float32[np.ndarray, "2 2"]  # noqa: F722
         float64: jaxtyping.Float64[np.ndarray, "2 2"]  # noqa: F722
@@ -111,8 +110,7 @@ def test_numpy_simple(se, de, opt):
 
         def __eq__(self, other):
             return (
-                (self.float_ == other.float_).all()
-                and (self.float16 == other.float16).all()
+                (self.float16 == other.float16).all()
                 and (self.float32 == other.float32).all()
                 and (self.float64 == other.float64).all()
                 and (self.inexact == other.inexact).all()
@@ -130,11 +128,10 @@ def test_numpy_simple(se, de, opt):
             )
 
     jaxtyping_test = NumpyJaxtyping(
-        float_=np.array([[1, 2], [3, 4]], dtype=np.float_),
         float16=np.array([[5, 6], [7, 8]], dtype=np.float16),
         float32=np.array([[9, 10], [11, 12]], dtype=np.float32),
         float64=np.array([[13, 14], [15, 16]], dtype=np.float64),
-        inexact=np.array([[17, 18], [19, 20]], dtype=np.float_),
+        inexact=np.array([[17, 18], [19, 20]], dtype=np.float64),
         int_=np.array([[21, 22], [23, 24]], dtype=np.int_),
         int8=np.array([[25, 26], [27, 28]], dtype=np.int8),
         int16=np.array([[29, 30], [31, 32]], dtype=np.int16),


### PR DESCRIPTION
This adds support for `numpy>2.0.0` by:

- Update the upper version restriction from `<2.0.0` to `<3.0.0` for all supported python versions
- Add [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation/) ruff rule for reporting uses of functions and constants deprecated in NumPy 2.0
- Remove usage of `np.float_` (which is a direct [alias](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace:~:text=get_array_wrap-,float_,-Use%20np.float64) for `np.float64`) from tests and numpy example 

Closes #562 