### PR TITLE
decorators.md: quote "Bar" forward reference

### DIFF
--- a/docs/en/decorators.md
+++ b/docs/en/decorators.md
@@ -96,7 +96,7 @@ from __future__ import annotations # make sure to import annotations
 class Foo:
     i: int
     s: str
-    bar: Bar  # Bar can be specified although it's declared afterward.
+    bar: "Bar"  # Bar can be specified although it's declared afterward.
 
 @serde
 @dataclass


### PR DESCRIPTION
The point of forward references is that they are strings. Adding the forgotten quotes.