### PR TITLE
Cache through type rather than string

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -760,7 +760,7 @@ def literal_func_name(literal_args: Sequence[Any]) -> str:
     )
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class Tagging:
     """
     Controls how union is (de)serialized. This is the same concept as in

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -842,3 +842,25 @@ def test_union_internal_tagging_for_non_dataclass() -> None:
 
     f = Foo([10])
     assert f == from_json(Foo, to_json(f))
+
+
+def test_union_internal_tagging_cache_conflict_different_case() -> None:
+    @serde
+    class Foo:
+        v: int
+
+    @serde
+    class Bar:
+        v: int
+
+    union_upper = InternalTagging("TAG")(Union[Foo, Bar])
+    deserialized_upper = Foo(1)
+    serialized_upper = '{"v":1,"TAG":"Foo"}'
+    assert from_json(union_upper, serialized_upper) == deserialized_upper
+    assert to_json(deserialized_upper, union_upper) == serialized_upper
+
+    union_lower = InternalTagging("tag")(Union[Foo, Bar])
+    deserialized_lower = Foo(1)
+    serialized_lower = '{"v":1,"tag":"Foo"}'
+    assert from_json(union_lower, serialized_lower) == deserialized_lower
+    assert to_json(deserialized_lower, union_lower) == serialized_lower


### PR DESCRIPTION
First merge https://github.com/yukinarit/pyserde/pull/662

This implements caching through the type or type construct (with tagging information) rather than trying to serialize that information into a string. This fixes the issue illustrated by https://github.com/yukinarit/pyserde/pull/664
