### PR TITLE
Add number coercion options for JSON/YAML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:24.04
+
+# Install Python 3.14 from deadsnakes PPA (if available)
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y python3.14 python3.14-venv && \
+	#python3.14-distutils &&  \
+    apt-get clean
+
+# Optional: set python3 to python3.14
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 1
+

--- a/bench/bench.py
+++ b/bench/bench.py
@@ -93,7 +93,7 @@ class Bencher:
             try:
                 import matplotlib.pyplot as plt
                 import numpy as np
-                import seaborn as sns
+                import seaborn as sns  # type: ignore[import]
 
                 x = np.array([r[0] for r in self.result])
                 y = np.array([r[1] for r in self.result])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,8 @@ source = "vcs"
 packages = ["serde"]
 
 [tool.black]
-target_version = ["py312"]
-line_length = 100
+target-version = ["py312"]
+line-length = 100
 
 [tool.pyright]
 include = [

--- a/serde/core.py
+++ b/serde/core.py
@@ -23,6 +23,7 @@ from typing import (
     Protocol,
     get_type_hints,
     Union,
+    cast,
 )
 
 from .compat import (
@@ -206,7 +207,12 @@ class Cache:
         func_name = union_func_name(UNION_SE_PREFIX, list(type_args(union_cls)))
         return scope.funcs[func_name](obj, False, False)
 
-    def deserialize_union(self, cls: type[T], data: Any) -> T:
+    def deserialize_union(
+        self,
+        cls: type[T],
+        data: Any,
+        deserialize_numbers: Optional[Callable[[Union[str, int]], float]] = None,
+    ) -> T:
         """
         Deserialize from dict or tuple into the specified Union.
         """
@@ -214,7 +220,12 @@ class Cache:
         wrapper = self._get_union_class(cls)
         scope: Scope = getattr(wrapper, SERDE_SCOPE)
         func_name = union_func_name(UNION_DE_PREFIX, list(type_args(union_cls)))
-        return scope.funcs[func_name](cls=union_cls, data=data)  # type: ignore
+        return cast(
+            T,
+            scope.funcs[func_name](
+                cls=union_cls, data=data, deserialize_numbers=deserialize_numbers
+            ),
+        )
 
 
 def _extract_from_with_tagging(maybe_with_tagging: Any) -> tuple[Any, Tagging]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,9 @@
 test=pytest
 [tool:pytest]
 addopts = -v
+
+[pycodestyle]
+max-line-length = 100
+
+[flake8]
+max-line-length = 100

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -52,8 +52,9 @@ def test_types() -> None:
     assert is_tuple(tuple)
     assert is_dict(dict)
 
+    Int = NewType("Int", int)
     assert is_primitive(int)
-    assert is_primitive(NewType("Int", int))
+    assert is_primitive(Int)  # type: ignore[arg-type]
 
     if sys.version_info[:3] >= (3, 10, 0):
         assert is_union(str | int)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,6 +1,9 @@
+import pytest
+
+import serde as serde_pkg
 from serde import serde
 from serde.yaml import to_yaml, from_yaml
-from typing import Optional
+from typing import Optional, Union
 
 
 def test_yaml_basics() -> None:
@@ -43,3 +46,45 @@ b: 100
 a: 10
 """
     )
+
+
+def test_coerce_numbers_yaml() -> None:
+    @serde
+    class Foo:
+        value: float
+
+    foo = from_yaml(Foo, "value: 1\n")
+    assert foo.value == 1.0
+
+    @serde
+    class Bar:
+        values: list[float]
+
+    bar = from_yaml(Bar, 'values:\n- 1\n- "2"\n')
+    assert bar.values == [1.0, 2.0]
+
+    baz = from_yaml(Foo, "value: 1e-3\n")
+    assert baz.value == 0.001
+
+    with pytest.raises(serde_pkg.SerdeError):
+        from_yaml(Foo, "value: 1\n", coerce_numbers=False)
+
+
+def test_yaml_numbers_with_union() -> None:
+    @serde
+    class Foo:
+        value: Union[float, int]
+
+    assert from_yaml(Foo, "value: 1\n").value == 1.0
+
+    with pytest.raises(serde_pkg.SerdeError):
+        from_yaml(Foo, 'value: "1"\n')
+
+    @serde
+    class Bar:
+        value: Union[int, float]
+
+    assert from_yaml(Bar, "value: 1\n").value == 1
+
+    with pytest.raises(serde_pkg.SerdeError):
+        from_yaml(Bar, 'value: "1"\n')


### PR DESCRIPTION
- Added opt-in number coercion support: new deserialize_numbers
  plumbing and flags for JSON/YAML deserialization, plus updated
  docs and tests (including union cases).
- Minor config/bench tweaks and formatting updates as part of the
  change.

If you want to disable coercion, you can pass `coerce_numbers=False` to the functions.

```python
from_json(..., coerce_numbers=False)
```
```python
from_yaml(..., coerce_numbers=False)
```


Closes #667