### PR TITLE
fix: compatibility with typing-extensions 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "typing-inspect>=0.4.0",
-  "typing_extensions>=4.1.0,<4.13.0",
+  "typing_extensions>=4.1.0,<4.16.0",
   "casefy",
   "jinja2",
   "plum-dispatch>=2.3",

--- a/serde/compat.py
+++ b/serde/compat.py
@@ -14,13 +14,23 @@ import sys
 import types
 import uuid
 import typing
+import typing_extensions
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import is_dataclass
 from typing import TypeVar, Generic, Any, ClassVar, Optional, NewType, Union, Hashable, Callable
 
 import typing_inspect
-from typing_extensions import TypeGuard, ParamSpec, TypeAliasType
+from typing_extensions import TypeGuard, ParamSpec
+
+# `typing_extensions.TypeAliasType` isn't always an alias to `typing.TypeAliasType`
+# depending on certain versions of `typing_extensions` and python.
+_PEP695_TYPES: tuple[type, ...]
+if hasattr(typing, "TypeAliasType"):
+    _PEP695_TYPES = (typing_extensions.TypeAliasType, typing.TypeAliasType)
+else:
+    _PEP695_TYPES = (typing_extensions.TypeAliasType,)
+
 
 # Lazy SQLAlchemy imports to improve startup time
 
@@ -882,7 +892,7 @@ def is_pep695_type_alias(typ: Any) -> bool:
     """
     Test if the type is of PEP695 type alias.
     """
-    return isinstance(typ, TypeAliasType)
+    return isinstance(typ, _PEP695_TYPES)
 
 
 @cache

--- a/uv.lock
+++ b/uv.lock
@@ -1322,7 +1322,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'toml'" },
     { name = "tomli-w", marker = "extra == 'all'" },
     { name = "tomli-w", marker = "extra == 'toml'" },
-    { name = "typing-extensions", specifier = ">=4.1.0,<4.13.0" },
+    { name = "typing-extensions", specifier = ">=4.1.0,<4.16.0" },
     { name = "typing-inspect", specifier = ">=0.4.0" },
 ]
 provides-extras = ["all", "jaxtyping", "msgpack", "numpy", "orjson", "sqlalchemy", "toml", "yaml"]
@@ -1688,11 +1688,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What it says on the tin. Boring, except for an edge case where recent `typing-extensions` have fallback behaviour for an edge case (see https://github.com/python/cpython/pull/124795).