### PR TITLE
Fix the guide destination dir as per mdbook v0.5 change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,10 @@ check:
 
 docs:
 	mkdir -p docs out/api out/guide/en
+	mkdir -p docs out/api out/guide/ja
 	$(UV) run pdoc -e serde=https://github.com/yukinarit/pyserde/tree/main/serde/ serde -o out/api
-	mdbook build -d ../../out/guide/en ./docs/en
-	mdbook build -d ../../out/guide/ja ./docs/ja
+	mdbook build -d ./out/guide/en ./docs/en
+	mdbook build -d ./out/guide/ja ./docs/ja
 
 open-docs:
 	$(UV) run pdoc -e serde=https://github.com/yukinarit/pyserde/tree/main/serde serde


### PR DESCRIPTION
mdbook v0.5 has a breaking change in --dest-dir option. https://github.com/rust-lang/mdBook/pull/2806