### PR TITLE
skip ignored fields in compat walkers

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -353,7 +353,8 @@ def iter_types(cls: type[Any]) -> list[type[Any]]:
             lst.add(cls)
             if isinstance(cls, type):
                 for f in dataclass_fields(cls):
-                    recursive(f.type)
+                    if not f.metadata.get("serde_skip"):
+                        recursive(f.type)
         elif isinstance(cls, str):
             lst.add(cls)
         elif is_opt(cls):
@@ -469,7 +470,8 @@ def iter_literals(cls: type[Any]) -> list[TypeLike]:
             stack.append(cls)
             if isinstance(cls, type):
                 for f in dataclass_fields(cls):
-                    recursive(f.type)
+                    if not f.metadata.get("serde_skip"):
+                        recursive(f.type)
             stack.pop()
         elif is_opt(cls):
             args = type_args(cls)

--- a/tests/test_literal.py
+++ b/tests/test_literal.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -194,3 +195,17 @@ def test_msgpack_unnamed() -> None:
     d = b"\x94\x01\xa3foo\xc3\xa3bar"
     assert d == serde.msgpack.to_msgpack(p, named=False)
     assert p == serde.msgpack.from_msgpack(Literals, d, named=False)
+
+
+def test_skip_literal_enum_field() -> None:
+    class Choice(enum.Enum):
+        X = "x"
+
+    @serde.serde
+    class Foo:
+        name: str
+        ignored: Literal[Choice.X] = serde.field(default=Choice.X, skip=True)
+
+    value = Foo("test")
+    assert {"name": "test"} == serde.to_dict(value)
+    assert value == serde.from_dict(Foo, {"name": "test"})

--- a/tests/test_type_alias.py
+++ b/tests/test_type_alias.py
@@ -3,7 +3,7 @@ import typing
 
 import pytest
 
-from serde import serde, from_dict, to_dict
+from serde import serde, field, from_dict, to_dict
 
 try:
     from typing import TypeAliasType
@@ -94,3 +94,29 @@ def test_typealiastype_nested_alias() -> None:
 
     value = Foo("alias", [1, 2, 3])
     assert value == from_dict(Foo, to_dict(value))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason=_PEP695_REASON)
+def test_pep695_recursive_type_alias_skipped_field() -> None:
+    ns: dict[str, object] = {
+        "field": field,
+        "from_dict": from_dict,
+        "serde": serde,
+        "to_dict": to_dict,
+    }
+    exec(
+        """
+type NestedDict = dict[str, NestedDict | int]
+
+@serde
+class Config:
+    name: str
+    internal: NestedDict | None = field(default=None, skip=True)
+""",
+        ns,
+    )
+    Config = typing.cast(type, ns["Config"])
+
+    value = Config(name="test")
+    assert {"name": "test"} == to_dict(value)
+    assert value == from_dict(Config, {"name": "test"})


### PR DESCRIPTION
This is a follow-up for #722. The code is generated by LLM, but I have reviewed it.

This patch makes the recursive walkers in `serde.compat` respect `serde_skip` for:
- `iter_types()`
- `iter_literals()`

## Failing cases

### 1. Recursive PEP 695 alias on a skipped field

On Python 3.12+, this fails during `@serde` decoration because `iter_types()` expands the skipped field type anyway and recurses forever:

```python
type NestedDict = dict[str, NestedDict | int]

@serde
class Config:
    name: str
    internal: NestedDict | None = field(default=None, skip=True)
```

Observed failure:

- RecursionError from serde.compat.iter_types()

### 2. Skipped `Literal[EnumMember]` field

This also should be harmless, but iter_literals() still walked the skipped field and generated a literal deserializer for it:

```python
class Choice(enum.Enum):
  X = "x"

@serde
class Foo:
    name: str
    ignored: Literal[Choice.X] = serde.field(default=Choice.X, skip=True)
```

Without this fix, pyserde can fail at decoration/codegen time because enum-valued literals render invalid Python in the generated literal helper.

## Fix

When recursively visiting dataclass fields in `serde.compat`, skip fields with `f.metadata["serde_skip"]`.

That keeps ignored fields out of the internal type/literal discovery phase, which matches the intended runtime behavior: ignored fields should not affect generated serde code.

## Tests

Added regressions for both user-visible failures:

- skipped recursive PEP 695 alias field
- skipped `Literal[EnumMember]` field