### PR TITLE
Reject None for non-optional field in coerce mode

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -1139,18 +1139,17 @@ strict = TypeCheck(kind=TypeCheck.Kind.Strict)
 
 
 def coerce_object(cls: str, field: str, typ: type[Any], obj: Any) -> Any:
+    if obj is None:
+        raise SerdeError(
+            f"failed to coerce the field {cls}.{field} value {obj} into {typename(typ)}: "
+            "None is not allowed for non-optional fields"
+        )
     try:
-        return typ(obj) if is_coercible(typ, obj) else obj
+        return typ(obj)
     except Exception as e:
         raise SerdeError(
             f"failed to coerce the field {cls}.{field} value {obj} into {typename(typ)}: {e}"
         )
-
-
-def is_coercible(typ: type[Any], obj: Any) -> bool:
-    if obj is None:
-        return False
-    return True
 
 
 def has_default(field: Field[Any]) -> bool:

--- a/tests/test_type_check.py
+++ b/tests/test_type_check.py
@@ -119,6 +119,9 @@ def test_uncoercible() -> None:
     with pytest.raises(serde.SerdeError):
         serde.from_dict(Foo, {"i": "foo"})
 
+    with pytest.raises(serde.SerdeError):
+        serde.from_dict(Foo, {"i": None})
+
 
 def test_coerce() -> None:
     @serde.serde(type_check=serde.coerce)


### PR DESCRIPTION
Currently, `type_check=coerce` lets the deserializer silently accept `None` for a non-optional field, which is inconsistent with the documentation. For example:

```python
import serde

@serde.serde(type_check=serde.coerce)
class A:
    a: int = 0

print(serde.from_dict(A, {"a": None}))
```

The above code outputs the following before the fix:

```python
A(a=None)
```

But a `SerdeError` is expected.

Here, we raise `SerdeError` when `coerce_object()` receives `None` for a non-optional field.