### PR TITLE
Improve missing field error messages

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -1288,10 +1288,18 @@ def {{func}}(cls=cls, maybe_generic=None, maybe_generic_type_vars=None, data=Non
   {% endif %}
 
   {% for f in fields %}
+  {% set field_arg = arg(f,loop.index-1) %}
   {% if f.flatten and is_flatten_dict(f.type) %}
   __{{f.name}} = __flatten_extra
+  {% elif field_arg.supports_default() %}
+  __{{f.name}} = {{rvalue(field_arg)}}
   {% else %}
-  __{{f.name}} = {{rvalue(arg(f,loop.index-1))}}
+  try:
+    __{{f.name}} = {{rvalue(field_arg)}}
+  except KeyError:
+    raise SerdeError(
+      "missing required field '{{field_arg.conv_name()}}' while deserializing {{class_name}}"
+    )
   {% endif %}
   {% endfor %}
 
@@ -1503,6 +1511,7 @@ def render_from_dict(
             fields=fields,
             type_check=type_check,
             cls_type_vars=get_type_var_names(cls),
+            class_name=typename(cls),
             rvalue=renderer.render,
             arg=functools.partial(to_arg, rename_all=rename_all),
             deny_unknown_fields=deny_unknown_fields,

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -994,8 +994,10 @@ def test_exception_to_from_obj() -> None:
     class Bar:
         pass
 
-    with pytest.raises(serde.SerdeError):
+    with pytest.raises(serde.SerdeError) as exc_info:
         serde.from_dict(Foo, {})
+
+    assert str(exc_info.value) == "missing required field 'a' while deserializing Foo"
 
 
 def test_user_error() -> None:


### PR DESCRIPTION
Missing required fields currently surface as a bare `SerdeError("'field'")`. For example,

```python
import serde


@serde.serde()
class A:
    a: int


print(serde.from_dict(A, {}))
```

The above code raises the following error before the fix:

```
serde.compat.SerdeError: 'a'
```

Here we catch that `KeyError` at the required-field lookup site, so pyserde raises a contextual `SerdeError` with the field and class name while leaving defaulted-field fallback behavior unchanged.

After the fix, the message becomes:

```
serde.compat.SerdeError: missing required field 'a' while deserializing A
```

---

The fix was done with the assistance of LLM, and I reviewed and tested it. It looks reasonable, but I'm not certain if the fix is ideal.