### PR TITLE
Fix flattened child unknown fields

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -258,6 +258,12 @@ class Scope:
     defaults: dict[str, Callable[..., Any] | Any] = dataclasses.field(default_factory=dict)
     """ Default values of the dataclass fields (factories & normal values) """
 
+    de_known_fields: set[str] = dataclasses.field(default_factory=set)
+    """ Field names accepted by the generated from_dict function """
+
+    de_has_flatten_dict: bool = False
+    """ True when generated from_dict or a flattened child captures unknown fields """
+
     code: dict[str, str] = dataclasses.field(default_factory=dict)
     """ Generated source code (only filled when debug is True) """
 

--- a/serde/de.py
+++ b/serde/de.py
@@ -167,6 +167,31 @@ def _exists_by_aliases(d: dict[str, str], aliases: list[str]) -> bool:
     return False
 
 
+def _project_flattened_data(
+    data: dict[str, Any] | None,
+    child_known_fields: set[str],
+    parent_known_fields: set[str],
+    child_has_flatten_dict: bool,
+    parent_has_flatten_dict: bool,
+) -> dict[str, Any]:
+    """
+    Select the portion of a flattened input map that should be visible to a child dataclass.
+
+    Parent fields must not be reported as unknown fields by a flattened child. Unknown fields
+    still need to pass through when no parent flatten dict captures them, or when the child has
+    its own flatten dict somewhere below it.
+    """
+    if not data:
+        return {}
+
+    keep_unknowns = child_has_flatten_dict or not parent_has_flatten_dict
+    if keep_unknowns:
+        return {
+            k: v for k, v in data.items() if k in child_known_fields or k not in parent_known_fields
+        }
+    return {k: v for k, v in data.items() if k in child_known_fields}
+
+
 def _make_deserialize(
     cls_name: str,
     fields: list[Any],
@@ -300,6 +325,7 @@ def deserialize(
         g["coerce_object"] = coerce_object
         g["_exists_by_aliases"] = _exists_by_aliases
         g["_get_by_aliases"] = _get_by_aliases
+        g["_project_flattened_data"] = _project_flattened_data
         g["class_deserializers"] = class_deserializers
         g["BeartypeCallHintParamViolation"] = BeartypeCallHintParamViolation
         g["is_bearable"] = is_bearable
@@ -1200,9 +1226,14 @@ class Renderer:
             return code
 
 
-def to_arg(f: DeField[T], index: int, rename_all: str | None = None) -> DeField[T]:
+def to_arg(
+    f: DeField[T],
+    index: int,
+    rename_all: str | None = None,
+    datavar: str = "data",
+) -> DeField[T]:
     f.index = index
-    f.data = "data"
+    f.data = datavar
     f.case = f.case or rename_all
     return f
 
@@ -1288,10 +1319,23 @@ def {{func}}(cls=cls, maybe_generic=None, maybe_generic_type_vars=None, data=Non
   {% endif %}
 
   {% for f in fields %}
-  {% set field_arg = arg(f,loop.index-1) %}
   {% if f.flatten and is_flatten_dict(f.type) %}
   __{{f.name}} = __flatten_extra
-  {% elif field_arg.supports_default() %}
+  {% else %}
+  {% set child_scope = flattened_dataclass_child_scopes.get(f.name) %}
+  {% if child_scope %}
+  __{{f.name}}_flatten_data = _project_flattened_data(
+    data,
+    {{ child_scope.de_known_fields }},
+    {{ known_fields }},
+    {{ child_scope.de_has_flatten_dict }},
+    {{ has_flatten_dict }},
+  )
+  {% set field_arg = arg(f,loop.index-1, datavar="__" ~ f.name ~ "_flatten_data") %}
+  {% else %}
+  {% set field_arg = arg(f,loop.index-1) %}
+  {% endif %}
+  {% if field_arg.supports_default() %}
   __{{f.name}} = {{rvalue(field_arg)}}
   {% else %}
   try:
@@ -1300,6 +1344,7 @@ def {{func}}(cls=cls, maybe_generic=None, maybe_generic_type_vars=None, data=Non
     raise SerdeError(
       "missing required field '{{field_arg.conv_name()}}' while deserializing {{class_name}}"
     )
+  {% endif %}
   {% endif %}
   {% endfor %}
 
@@ -1444,6 +1489,30 @@ def get_known_fields(f: DeField[Any], rename_all: str | None) -> list[str]:
     return names + f.alias
 
 
+def _collect_flattened_dataclass_child_scopes(fields: list[DeField[Any]]) -> dict[str, Scope]:
+    flattened_children: dict[str, Scope] = {}
+    for f in fields:
+        if not f.flatten or is_flatten_dict(f.type) or f.name is None:
+            continue
+
+        child_cls: type[Any] | None = None
+        if isinstance(f.type, type) and is_dataclass(f.type):
+            child_cls = cast(type[Any], f.type)
+        elif is_opt(f.type):
+            child_cls = next(
+                (
+                    cast(type[Any], arg)
+                    for arg in get_args(f.type)
+                    if isinstance(arg, type) and is_dataclass(arg)
+                ),
+                None,
+            )
+
+        if child_cls is not None:
+            flattened_children[f.name] = cast(Scope, getattr(child_cls, SERDE_SCOPE))
+    return flattened_children
+
+
 def _collect_known_fields(
     fields: list[DeField[Any]], rename_all: str | None, exclude_flatten_dict: bool = False
 ) -> set[str]:
@@ -1452,15 +1521,16 @@ def _collect_known_fields(
     When exclude_flatten_dict is True, skips flatten dict fields from the known fields set.
     For flattened dataclass fields, includes their nested field names.
     """
+    flattened_children = _collect_flattened_dataclass_child_scopes(fields)
     known: set[str] = set()
     for f in fields:
         # Skip flatten dict field itself - it captures "unknown" fields
         if exclude_flatten_dict and f.flatten and is_flatten_dict(f.type):
             continue
         # For flattened dataclass, include nested field names
-        if f.flatten and is_dataclass(f.type):
-            for nested_f in defields(f.type):
-                known.update(get_known_fields(nested_f, rename_all))
+        child_scope = flattened_children.get(f.name) if f.name is not None else None
+        if child_scope is not None:
+            known.update(child_scope.de_known_fields)
         else:
             known.update(get_known_fields(f, rename_all))
     return known
@@ -1490,6 +1560,8 @@ def render_from_dict(
         field.iterbased = False
         field.index = 0
         field.data = "fake_dict"
+        serde_scope.de_known_fields = {field.conv_name()}
+        serde_scope.de_has_flatten_dict = False
         res = jinja2_env.get_template("transparent_dict").render(
             func=FROM_DICT,
             serde_scope=serde_scope,
@@ -1501,9 +1573,16 @@ def render_from_dict(
     else:
         # Detect flatten dict field
         has_flatten_dict = any(f.flatten and is_flatten_dict(f.type) for f in fields)
+        flattened_dataclass_child_scopes = _collect_flattened_dataclass_child_scopes(fields)
+        has_flatten_dict_transitively = has_flatten_dict or any(
+            child_scope.de_has_flatten_dict
+            for child_scope in flattened_dataclass_child_scopes.values()
+        )
 
         # Compute known fields - exclude flatten dict field itself since it captures unknown fields
         known_fields = _collect_known_fields(all_fields, rename_all, exclude_flatten_dict=True)
+        serde_scope.de_known_fields = known_fields
+        serde_scope.de_has_flatten_dict = has_flatten_dict_transitively
 
         res = jinja2_env.get_template("dict").render(
             func=FROM_DICT,
@@ -1518,6 +1597,7 @@ def render_from_dict(
             known_fields=known_fields,
             has_flatten_dict=has_flatten_dict,
             is_flatten_dict=is_flatten_dict,
+            flattened_dataclass_child_scopes=flattened_dataclass_child_scopes,
         )
 
     if renderer.import_numpy:

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 import pytest
 
-from serde import field, serde, SerdeError
+from serde import field, from_dict, serde, SerdeError
 from serde.json import from_json, to_json
 
 from .common import all_formats
@@ -99,6 +99,19 @@ def test_flatten_default() -> None:
     assert from_json(Foo, to_json(f)) == f
 
     assert from_json(Foo, '{"a": 20}') == Foo(20, "foo", Bar())
+
+
+def test_flatten_default_with_empty_input() -> None:
+    @serde
+    class Bar:
+        c: float = field(default=0.0)
+        d: bool = field(default=False)
+
+    @serde
+    class Foo:
+        bar: Bar = field(flatten=True, default_factory=Bar)
+
+    assert from_dict(Foo, {}) == Foo(bar=Bar())
 
 
 def test_flatten_default_alias() -> None:
@@ -272,3 +285,92 @@ def test_flatten_bare_dict() -> None:
     assert '"a":20' in s2
     assert '"x":1' in s2
     assert '"y":"z"' in s2
+
+
+def test_flatten_deny_unknown_fields_excludes_parent_fields() -> None:
+    @serde(deny_unknown_fields=True)
+    class Inner:
+        a: int
+
+    @serde
+    class Outer:
+        b: int
+        inner: Inner = field(flatten=True)
+
+    assert from_dict(Outer, {"a": 1, "b": 2}) == Outer(b=2, inner=Inner(a=1))
+
+    with pytest.raises(SerdeError):
+        from_dict(Outer, {"a": 1, "b": 2, "unknown": 3})
+
+
+def test_flatten_deny_unknown_child_with_parent_extra() -> None:
+    @serde(deny_unknown_fields=True)
+    class Inner:
+        a: int
+
+    @serde
+    class Outer:
+        b: int
+        inner: Inner = field(flatten=True)
+        extra: dict[str, Any] = field(flatten=True, default_factory=dict)
+
+    assert from_dict(Outer, {"a": 1, "b": 2, "unknown": 3}) == Outer(
+        b=2, inner=Inner(a=1), extra={"unknown": 3}
+    )
+
+
+def test_flatten_parent_and_child_extra_both_capture_unknowns() -> None:
+    @serde
+    class Inner:
+        a: int
+        child_extra: dict[str, Any] = field(flatten=True, default_factory=dict)
+
+    @serde
+    class Outer:
+        b: int
+        inner: Inner = field(flatten=True)
+        parent_extra: dict[str, Any] = field(flatten=True, default_factory=dict)
+
+    assert from_dict(Outer, {"a": 1, "b": 2, "unknown": 3}) == Outer(
+        b=2,
+        inner=Inner(a=1, child_extra={"unknown": 3}),
+        parent_extra={"unknown": 3},
+    )
+
+
+def test_flatten_parent_and_grandchild_extra_both_capture_unknowns() -> None:
+    @serde
+    class Grand:
+        a: int
+        grand_extra: dict[str, Any] = field(flatten=True, default_factory=dict)
+
+    @serde
+    class Inner:
+        grand: Grand = field(flatten=True)
+
+    @serde
+    class Outer:
+        inner: Inner = field(flatten=True)
+        parent_extra: dict[str, Any] = field(flatten=True, default_factory=dict)
+
+    assert from_dict(Outer, {"a": 1, "unknown": 2}) == Outer(
+        inner=Inner(grand=Grand(a=1, grand_extra={"unknown": 2})),
+        parent_extra={"unknown": 2},
+    )
+
+
+def test_flatten_sibling_fields_do_not_leak_between_children() -> None:
+    @serde(deny_unknown_fields=True)
+    class Left:
+        a: int
+
+    @serde(deny_unknown_fields=True)
+    class Right:
+        b: int
+
+    @serde
+    class Outer:
+        left: Left = field(flatten=True)
+        right: Right = field(flatten=True)
+
+    assert from_dict(Outer, {"a": 1, "b": 2}) == Outer(left=Left(a=1), right=Right(b=2))


### PR DESCRIPTION
Previously, when we have a flattened child class with `deny_unknown_fields=True`, we will have a problem deserializing.

```python
import serde

@serde.serde(deny_unknown_fields=True)
class A:
    a: int

@serde.serde
class B:
    b: int
    a: A = serde.field(flatten=True, default_factory=A)

serde.from_dict(B, {"a": 1, "b": 2})
```

Actual behavior:

```text
serde.compat.SerdeError: unknown fields: {'b'}, expected one of {'a'}
```

Expected:

```python
B(b=2, a=A(a=1))
```

The fix strategy is passing only the relevant flattened input to child deserializers, achieved by knowing the exact keys expected by the flattened child. Special cases are flattened dict fields. If the parent has flattened dict fields whereas the flattened child does not, we will keep the unknown fields only visible by the parent. Otherwise, we will pass those to the child.

---

The changes are done by a coding agent, and I have reviewed the code by trying to understand the changes line by line. The changes are reasonable and readable.