### PR TITLE
Fix serialization of PEP 695 type-alias unions

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -456,6 +456,11 @@ def from_obj(
 
     res: Any
 
+    # A PEP 695 type alias (``type T = Foo | Bar``) is a TypeAliasType, not the
+    # aliased type itself, so unwrap it to recognize e.g. a union.
+    if is_pep695_type_alias(c):
+        c = c.__value__  # type: ignore[attr-defined]
+
     # It is possible that the parser already generates the correct data type requested
     # by the caller. Hence, it should be checked early to avoid doing anymore work.
     if type(o) is c:

--- a/serde/se.py
+++ b/serde/se.py
@@ -402,6 +402,11 @@ def to_obj(
             skip_none=skip_none,
         )
 
+        # A PEP 695 type alias (``type T = Foo | Bar``) is a TypeAliasType, not
+        # the aliased type itself, so unwrap it to recognize e.g. a union.
+        if c is not None and is_pep695_type_alias(c):
+            c = c.__value__
+
         # If a class in the argument is a non-dataclass class e.g. Union[Foo, Bar],
         # pyserde generates a wrapper (de)serializable dataclass on the fly,
         # and use it to serialize the object.

--- a/tests/test_type_alias.py
+++ b/tests/test_type_alias.py
@@ -57,6 +57,38 @@ class Bar:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason=_PEP695_REASON)
+def test_pep695_type_alias_as_top_level_union() -> None:
+    # A `type T = Foo | Bar` alias passed as the top-level `cls` must be treated
+    # as the union it aliases, not silently serialized without tagging. See #753.
+    ns: dict[str, object] = {"serde": serde}
+    exec(
+        """
+@serde
+class Foo:
+    a: int = 123
+
+@serde
+class Dummy:
+    b: int = 456
+
+type T = Foo | Dummy
+""",
+        ns,
+    )
+    Foo = typing.cast(type, ns["Foo"])
+    Dummy = typing.cast(type, ns["Dummy"])
+    T = ns["T"]
+
+    value = Foo()
+    expected = to_dict(value, c=typing.cast(type, Foo | Dummy))
+    assert expected == {"Foo": {"a": 123}}
+    # the alias must produce the same tagged output as the real union ...
+    assert to_dict(value, c=typing.cast(type, T)) == expected
+    # ... and round-trip back through the alias.
+    assert value == from_dict(typing.cast(type, T), to_dict(value, c=typing.cast(type, T)))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason=_PEP695_REASON)
 def test_pep695_type_alias_variable_tuple() -> None:
     ns: dict[str, object] = {"serde": serde}
     exec(


### PR DESCRIPTION
Fixes #753.

A PEP 695 `type T = Foo | Bar` alias is a `TypeAliasType`, not the union it aliases. When such an alias was passed as the top-level `cls`, `to_obj` / `from_obj` failed the `is_union(c)` check and fell through to plain (untagged) serialization, diverging from `cls=Foo | Bar`:

```python
type T = Foo | Dummy

to_json(Foo(), cls=T)          # {"a":123}            <- wrong, no tagging
to_json(Foo(), cls=Foo | Dummy) # {"Foo":{"a":123}}   <- expected
```

### Fix
Unwrap the alias to its `__value__` at the top of `to_obj` (se.py) and `from_obj` (de.py), so it is recognized as the union it stands for. This mirrors how PEP 695 aliases are already unwrapped on the field-rendering path (added in #669). Now `cls=T` matches `cls=Foo | Dummy` for both serialization and deserialization round-trips.

### Tests
Added `test_pep695_type_alias_as_top_level_union` in `tests/test_type_alias.py` (fails without the patch). Full suite green (5169 passed, excluding the numpy/jaxtyping-gated files).

Thanks to @Luffbee for the clear report and reproducer.