### PR TITLE
Delete 'latest' version before deploying docs to avoid alias conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Deploy docs with mike
         run: |
           git fetch origin gh-pages --depth=1
+          uv run mike delete --push latest || true
           uv run mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
           uv run mike set-default --push latest
         env:


### PR DESCRIPTION
mike fails with 'alias already specified as a version' when 'latest' exists as a standalone version rather than an alias. Delete it first so it can be created as an alias for the new release.