### PR TITLE
Fix custom field serializer inside a flattened field

### DIFF
--- a/serde/se.py
+++ b/serde/se.py
@@ -307,11 +307,7 @@ def serialize(
             add_func(scope, union_key, render_union_func(cls, union_args, tagging), g)
             scope.union_se_args[union_key] = union_args
 
-        for f in sefields(cls, serialize_class_var):
-            if f.skip_if:
-                g[f.skip_if.name] = f.skip_if
-            if f.serializer:
-                g[f.serializer.name] = f.serializer
+        add_field_serializers_to_scope(sefields(cls, serialize_class_var), g, serialize_class_var)
 
         add_func(
             scope,
@@ -601,6 +597,29 @@ def sefields(cls: type[Any], serialize_class_var: bool = False) -> Iterator[SeFi
     ):
         f.parent = SeField(None, "obj")  # type: ignore
         yield f
+
+
+def add_field_serializers_to_scope(
+    sfields: Iterator[SeField[Any]], g: dict[str, Any], serialize_class_var: bool = False
+) -> None:
+    """
+    Register custom field serializers and skip_if predicates in the generated globals.
+
+    A flattened dataclass field is rendered inline in the enclosing class's serialize
+    function, so the custom serializers and skip_if predicates of its inner fields must
+    be available in this scope too, not only those of the top-level fields (#453).
+    """
+    for f in sfields:
+        if f.skip_if:
+            g[f.skip_if.name] = f.skip_if
+        if f.serializer:
+            g[f.serializer.name] = f.serializer
+        if f.flatten:
+            inner = f[0] if is_opt(f.type) else f
+            if is_dataclass(inner.type):
+                add_field_serializers_to_scope(
+                    sefields(inner.type, serialize_class_var), g, serialize_class_var
+                )
 
 
 jinja2_env = jinja2.Environment(

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -30,6 +30,27 @@ def test_flatten_simple() -> None:
     assert from_json(Foo, s) == f
 
 
+def test_flatten_custom_field_serializer() -> None:
+    # A custom field serializer on a flattened dataclass's field must be in
+    # scope of the enclosing class's generated serializer (#453).
+    @serde
+    class Child:
+        value: int = field(serializer=str)
+
+    @serde
+    class Parent:
+        child: Child = field(flatten=True)
+
+    assert to_json(Parent(child=Child(value=3))) == '{"value":"3"}'
+
+    # also works through a nested flatten
+    @serde
+    class GrandParent:
+        parent: Parent = field(flatten=True)
+
+    assert to_json(GrandParent(parent=Parent(child=Child(value=7)))) == '{"value":"7"}'
+
+
 @pytest.mark.parametrize("se,de", all_formats)
 def test_flatten(se: Any, de: Any) -> None:
     @serde


### PR DESCRIPTION
Fixes #453.

A custom field serializer on a field of a flattened dataclass crashed serialization:

```python
@serialize
class Child:
    value: int = field(serializer=str)

@serialize
class Parent:
    child: Child = field(flatten=True)

to_dict(Parent(child=Child(value=3)))  # SerdeError: name 'value_serializer' is not defined
```

### Cause
A flattened dataclass field is rendered *inline* in the enclosing class's generated serialize function, so it emits references like `value_serializer(...)`. But the loop that registers custom field serializers (and `skip_if` predicates) in the generated globals only iterated the top-level fields — the flattened child's serializer was never put in scope.

### Fix
Recurse into flattened (and optional-flattened) dataclass fields when collecting field serializers / `skip_if` predicates, so they are available in the enclosing scope. Handles nested flattens too.

### Tests
Added `test_flatten_custom_field_serializer` (basic + nested flatten; fails without the patch). Full suite green (5169 passed). Deserialization was already unaffected (a flattened child is deserialized via its own scoped function).

Thanks @AustinScola for the report and minimal reproducer.