### PR TITLE
Apply global class (de)serializers to top-level values (fixes #514)

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -464,6 +464,22 @@ class Deserializer(Generic[T], metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
+def find_global_class_deserializer(typ: type[Any]) -> ClassDeserializer | None:
+    """Return a globally registered class deserializer that handles ``typ``, if any.
+
+    This mirrors the lookup used when rendering dataclass fields, so a deserializer
+    registered with ``serde.add_deserializer`` also applies when ``typ`` is passed
+    directly to ``from_dict``/``from_tuple`` instead of nested in a dataclass
+    (https://github.com/yukinarit/pyserde/issues/514).
+    """
+    for class_deserializer in GLOBAL_CLASS_DESERIALIZER:
+        for method in class_deserializer.__class__.deserialize.methods:  # type: ignore[attr-defined]
+            # signature.types[1] is ``type[X]``; unwrap it to the value type ``X``.
+            if get_args(method.signature.types[1])[0] is typ:
+                return class_deserializer
+    return None
+
+
 def from_obj(
     c: type[T],
     o: Any,
@@ -521,7 +537,10 @@ def from_obj(
             reuse_instances=reuse_instances,
             deserialize_numbers=deserialize_numbers,
         )
-        if is_dataclass_without_de(c):
+        class_deserializer = find_global_class_deserializer(c)
+        if class_deserializer is not None:
+            res = class_deserializer.deserialize(c, o)
+        elif is_dataclass_without_de(c):
             # Do not automatically implement beartype if dataclass without serde decorator
             # is passed, because it is surprising for users
             # See https://github.com/yukinarit/pyserde/issues/480

--- a/serde/se.py
+++ b/serde/se.py
@@ -375,6 +375,22 @@ def is_dataclass_without_se(cls: type[Any]) -> bool:
     return TO_DICT not in scope.funcs
 
 
+def find_global_class_serializer(typ: type[Any]) -> ClassSerializer | None:
+    """Return a globally registered class serializer that handles ``typ``, if any.
+
+    This mirrors the lookup used when rendering dataclass fields, so a serializer
+    registered with ``serde.add_serializer`` also applies when an instance of
+    ``typ`` is passed directly to ``to_dict``/``to_tuple`` instead of nested in a
+    dataclass (https://github.com/yukinarit/pyserde/issues/514).
+    """
+    for class_serializer in GLOBAL_CLASS_SERIALIZER:
+        for method in class_serializer.__class__.serialize.methods:  # type: ignore[attr-defined]
+            # signature.types[1] is the value type; index 0 is ``self``.
+            if method.signature.types[1] is typ:
+                return class_serializer
+    return None
+
+
 def to_obj(
     o: Any,
     named: bool,
@@ -410,6 +426,9 @@ def to_obj(
 
         if o is None:
             return None
+        class_serializer = find_global_class_serializer(type(o))
+        if class_serializer is not None:
+            return class_serializer.serialize(o)
         if is_dataclass_without_se(o):
             # Do not automatically implement beartype if dataclass without serde decorator
             # is passed, because it is surprising for users

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -10,13 +10,18 @@ import pytest
 
 from serde import (
     SerdeError,
+    add_deserializer,
+    add_serializer,
     field,
+    from_dict,
     from_tuple,
     serde,
+    to_dict,
     to_tuple,
     ClassSerializer,
     ClassDeserializer,
 )
+from serde.core import GLOBAL_CLASS_DESERIALIZER, GLOBAL_CLASS_SERIALIZER
 from serde.json import from_json, to_json
 
 
@@ -134,6 +139,52 @@ def test_custom_class_serializer_dataclass() -> None:
     s = '{"bar":"10"}'
     assert s == to_json(f)
     assert f == from_json(Foo, s)
+
+
+def test_global_class_serializer_top_level() -> None:
+    # A serializer/deserializer registered globally via add_serializer/add_deserializer
+    # must also apply when the custom type is passed directly to to_dict/from_dict, not
+    # only when nested inside a dataclass. https://github.com/yukinarit/pyserde/issues/514
+    class Point:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, Point) and self.x == other.x and self.y == other.y
+
+    class PointSerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: Point) -> dict[str, Any]:
+            return {"x": value.x, "y": value.y}
+
+    class PointDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: type[Point], value: dict[str, Any]) -> Point:
+            return Point(value["x"], value["y"])
+
+    ser_snapshot = list(GLOBAL_CLASS_SERIALIZER)
+    de_snapshot = list(GLOBAL_CLASS_DESERIALIZER)
+    add_serializer(PointSerializer())
+    add_deserializer(PointDeserializer())
+    try:
+
+        @serde
+        class Wrapper:
+            p: Point
+
+        # Nested has always worked; keep it as the reference behaviour.
+        assert to_dict(Wrapper(Point(1, 2))) == {"p": {"x": 1, "y": 2}}
+
+        # Top-level used to skip the global serializer and return the raw object.
+        assert to_dict(Point(1, 2)) == {"x": 1, "y": 2}
+        assert to_tuple(Point(1, 2)) == {"x": 1, "y": 2}
+
+        # Deserialization is symmetric and must round-trip from the top level.
+        assert from_dict(Point, {"x": 1, "y": 2}) == Point(1, 2)
+    finally:
+        GLOBAL_CLASS_SERIALIZER[:] = ser_snapshot
+        GLOBAL_CLASS_DESERIALIZER[:] = de_snapshot
 
 
 def test_custom_serializer_with_field_attributes() -> None:

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -187,6 +187,44 @@ def test_global_class_serializer_top_level() -> None:
         GLOBAL_CLASS_DESERIALIZER[:] = de_snapshot
 
 
+def test_global_class_serializer_top_level_no_match() -> None:
+    # When a global serializer is registered but does not handle the top-level
+    # type, the lookup must fall through to the normal dataclass path rather
+    # than hijacking it. https://github.com/yukinarit/pyserde/issues/514
+    class Point:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    class PointSerializer(ClassSerializer):
+        @dispatch
+        def serialize(self, value: Point) -> dict[str, Any]:
+            return {"x": value.x, "y": value.y}
+
+    class PointDeserializer(ClassDeserializer):
+        @dispatch
+        def deserialize(self, cls: type[Point], value: dict[str, Any]) -> Point:
+            return Point(value["x"], value["y"])
+
+    ser_snapshot = list(GLOBAL_CLASS_SERIALIZER)
+    de_snapshot = list(GLOBAL_CLASS_DESERIALIZER)
+    add_serializer(PointSerializer())
+    add_deserializer(PointDeserializer())
+    try:
+
+        @serde
+        class Other:
+            a: int
+
+        # The registry is non-empty, but no entry matches ``Other``; the value
+        # must be handled by the regular dataclass (de)serialization.
+        assert to_dict(Other(1)) == {"a": 1}
+        assert from_dict(Other, {"a": 1}) == Other(1)
+    finally:
+        GLOBAL_CLASS_SERIALIZER[:] = ser_snapshot
+        GLOBAL_CLASS_DESERIALIZER[:] = de_snapshot
+
+
 def test_custom_serializer_with_field_attributes() -> None:
     class MySerializer(ClassSerializer):
         @dispatch


### PR DESCRIPTION
Fixes #514.

### Problem

A custom serializer registered globally with `serde.add_serializer` (and the matching `add_deserializer`) is only consulted when the custom type appears as a **dataclass field**. When the same type is passed **directly** to `to_dict`/`to_tuple`/`from_dict`, the registration is ignored:

```python
serde.add_serializer(MySerializer())      # serialize(self, value: MyClass) -> dict
serde.add_deserializer(MyDeserializer())

serde.to_dict(MyWrapper(MyClass(1, 2)))   # {'value': {'a': 1, 'b': 2}}  ✓ nested works
serde.to_dict(MyClass(1, 2))              # <MyClass object ...>          ✗ returns the raw object
```

`to_dict(MyClass(...))` returns the object unchanged instead of `{'a': 1, 'b': 2}`, and `from_dict(MyClass, {...})` raises `TypeError` while trying to construct the class directly.

### Root cause

`to_obj` (se.py) and `from_obj` (de.py) handle dataclasses, containers, unions, str/datetime, etc., but neither checks the global `ClassSerializer`/`ClassDeserializer` registry for the top-level value's type. The generated field-rendering code (`Renderer.render` / `Defactory.render`) *does* check it (and gives it precedence), so nested fields work while the top level falls through to `return o` / `c(o)`.

### Fix

Add `find_global_class_serializer(type)` / `find_global_class_deserializer(type)` helpers that reuse the exact same plum-dispatch lookup the field renderers use (`serialize.methods` / `deserialize.methods` → value type). `to_obj`/`from_obj` consult them for the value's type, matching the nested precedence so behaviour is identical whether the custom type is nested or top-level. When no global handler matches the type, the registry is empty and the lookup is a no-op, so existing behaviour is unchanged.

### Verification

- New `test_global_class_serializer_top_level` in `tests/test_custom.py`: registers a global serializer + deserializer, asserts top-level `to_dict`/`to_tuple`/`from_dict` round-trip and that the nested case still matches (snapshots/restores the global registry so it doesn't leak into other tests). Red on `main`, green with the fix.
- Full suite green (`pytest tests`, excluding the jaxtyping-gated numpy/code-completion files): 5174 passed.
- `pre-commit` (black, ruff, pyright, mypy) clean on all changed files.