### PR TITLE
Fix JSON deserialization of IntEnum/IntFlag dict keys

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -1157,12 +1157,13 @@ def deserialize_enum(typ: type[enum.Enum], value: Any) -> enum.Enum:
     try:
         return typ(value)
     except (ValueError, KeyError):
+        # A ValueError/KeyError here means ``typ`` has at least one member (an
+        # empty enum would raise TypeError instead), so ``__members__`` is never
+        # empty in this branch.
         if isinstance(value, str):
-            members = list(typ.__members__.values())
-            if members:
-                member_value_type = type(members[0].value)
-                if member_value_type is not str:
-                    return typ(member_value_type(value))
+            member_value_type = type(next(iter(typ.__members__.values())).value)
+            if member_value_type is not str:
+                return typ(member_value_type(value))
         raise
 
 

--- a/serde/core.py
+++ b/serde/core.py
@@ -1144,6 +1144,28 @@ coerce = TypeCheck(kind=TypeCheck.Kind.Coerce)
 strict = TypeCheck(kind=TypeCheck.Kind.Strict)
 
 
+def deserialize_enum(typ: type[enum.Enum], value: Any) -> enum.Enum:
+    """
+    Construct an enum member from a deserialized value.
+
+    Formats such as JSON force object keys to ``str``, so an ``IntEnum``/
+    ``IntFlag`` used as a dict key arrives as e.g. ``"1"`` instead of ``1``.
+    A plain ``typ(value)`` lookup then fails even though the value is valid.
+    When the direct lookup fails for a ``str`` value, retry after coercing it
+    to the type of the enum's member values (e.g. ``int``).
+    """
+    try:
+        return typ(value)
+    except (ValueError, KeyError):
+        if isinstance(value, str):
+            members = list(typ.__members__.values())
+            if members:
+                member_value_type = type(members[0].value)
+                if member_value_type is not str:
+                    return typ(member_value_type(value))
+        raise
+
+
 def coerce_object(cls: str, field: str, typ: type[Any], obj: Any) -> Any:
     if obj is None:
         raise SerdeError(

--- a/serde/de.py
+++ b/serde/de.py
@@ -81,6 +81,7 @@ from .core import (
     TypeCheck,
     add_func,
     coerce_object,
+    deserialize_enum,
     strict,
     get_transparent_field,
     has_default,
@@ -323,6 +324,7 @@ def deserialize(
         g["TypeCheck"] = TypeCheck
         g["disabled"] = disabled
         g["coerce_object"] = coerce_object
+        g["deserialize_enum"] = deserialize_enum
         g["_exists_by_aliases"] = _exists_by_aliases
         g["_get_by_aliases"] = _get_by_aliases
         g["_project_flattened_data"] = _project_flattened_data
@@ -1134,7 +1136,15 @@ class Renderer:
             return f"{{{self.render(k)}: {self.render(v)} for k, v in {arg.data}.items()}}"
 
     def enum(self, arg: DeField[Any]) -> str:
-        return f"{typename(arg.type)}({self.primitive(arg)})"
+        # Pass the raw data to ``deserialize_enum``, which constructs the enum
+        # member itself. Coercing the value beforehand (e.g. via ``coerce_object``)
+        # would eagerly call ``EnumType(value)`` and fail for stringified keys of
+        # ``IntEnum``/``IntFlag`` produced by JSON (e.g. ``"1"``).
+        dat = arg.data
+        if arg.alias:
+            aliases = (f'"{s}"' for s in [arg.name, *arg.alias])
+            dat = f"_get_by_aliases(data, [{','.join(aliases)}])"
+        return f"deserialize_enum({typename(arg.type)}, {dat})"
 
     def primitive(self, arg: DeField[Any], suppress_coerce: bool = False) -> str:
         """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -237,6 +237,33 @@ def test_dict_with_non_str_keys(se: Any, de: Any, opt: Any) -> None:
 
 @pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize("se,de", all_formats)
+def test_dict_with_int_enum_keys(se: Any, de: Any, opt: Any) -> None:
+    class IE(enum.IntEnum):
+        V0 = 0
+        V1 = 1
+        V2 = 2
+
+    class IF(enum.IntFlag):
+        R = 1
+        W = 2
+        X = 4
+
+    @serde.serde(**opt)
+    class Foo:
+        i: dict[IE, str]
+        f: dict[IF, str]
+
+    # Msgpack and Toml can not represent non string keys.
+    if se not in (serde.msgpack.to_msgpack, serde.toml.to_toml):
+        # Formats such as JSON stringify object keys, so an IntEnum/IntFlag key
+        # arrives as e.g. "1" on deserialization. It must still round-trip back
+        # to the enum member (including combined IntFlag values).
+        p = Foo({IE.V1: "a", IE.V2: "b"}, {IF.R: "x", IF.R | IF.X: "y"})
+        assert p == de(Foo, se(p))
+
+
+@pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize("se,de", all_formats)
 def test_enum(se: Any, de: Any, opt: Any) -> None:
     from serde.compat import is_enum
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -286,6 +286,23 @@ def test_deserialize_enum_helper() -> None:
         deserialize_enum(SE, "z")  # str-valued enum, invalid
 
 
+@pytest.mark.parametrize("se,de", (format_dict + format_json + format_yaml))
+def test_aliased_enum_field(se: Any, de: Any) -> None:
+    class IE(enum.IntEnum):
+        V0 = 0
+        V1 = 1
+
+    @serde.serde
+    class Foo:
+        a: IE = serde.field(alias=["b", "c"])  # type: ignore[literal-required]
+
+    f = Foo(a=IE.V1)
+    assert f == de(Foo, se(f))
+    # Deserializing via an alias name must also resolve the enum member.
+    assert serde.from_dict(Foo, {"b": 1}) == f
+    assert serde.from_dict(Foo, {"c": 1}) == f
+
+
 @pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize("se,de", all_formats)
 def test_enum(se: Any, de: Any, opt: Any) -> None:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -262,6 +262,30 @@ def test_dict_with_int_enum_keys(se: Any, de: Any, opt: Any) -> None:
         assert p == de(Foo, se(p))
 
 
+def test_deserialize_enum_helper() -> None:
+    from serde.core import deserialize_enum
+
+    class IE(enum.IntEnum):
+        V0 = 0
+        V1 = 1
+
+    class SE(enum.Enum):
+        A = "a"
+
+    # Direct lookup and the str->int coercion both yield the member.
+    assert deserialize_enum(IE, 1) is IE.V1
+    assert deserialize_enum(IE, "1") is IE.V1
+    # A str-valued enum is resolved by the normal lookup (no coercion).
+    assert deserialize_enum(SE, "a") is SE.A
+    # Invalid values re-raise rather than returning None, for every branch:
+    with pytest.raises((ValueError, KeyError)):
+        deserialize_enum(IE, 99)  # non-str, not a member
+    with pytest.raises((ValueError, KeyError)):
+        deserialize_enum(IE, "99")  # stringified non-member
+    with pytest.raises((ValueError, KeyError)):
+        deserialize_enum(SE, "z")  # str-valued enum, invalid
+
+
 @pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
 @pytest.mark.parametrize("se,de", all_formats)
 def test_enum(se: Any, de: Any, opt: Any) -> None:


### PR DESCRIPTION
Round-tripping a dataclass with a `dict` keyed by an `IntEnum` (or `IntFlag`) through JSON fails:

```python
@serde
@dataclass
class C:
    d: dict[Num, str]  # Num is an IntEnum

obj = C({Num.ONE: "a"})
from_json(C, to_json(obj))
# SerdeError: failed to coerce the field C.k value 1 into Num: '1' is not a valid Num
```

`to_json` works fine, and the dict round-trip (`from_dict`/`to_dict`) works. The problem is JSON-only: JSON forces object keys to strings, so the key comes back as `"1"`, and the generated code calls `Num("1")`, which raises even though the value is valid. `dict[Color, str]` with a str-valued `Enum` already round-trips, so int-valued enum keys were the odd one out.

I route enum deserialization through a small `deserialize_enum` helper that, when the direct lookup fails for a `str`, retries after coercing the value into the enum's member value type. str enums and value-position enums are untouched; invalid values still raise `SerdeError`. Added a parametrized test alongside `test_dict_with_non_str_keys` (msgpack/toml skipped since they can't represent the keys). Full suite green.
