### PR TITLE
Fix JSON deserialization of int/float dict keys

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -1160,11 +1160,31 @@ class Renderer:
                 # When the callable type is non generic type e.g int, Foo.
                 callable = v.type.__name__
             return f"collections.defaultdict({callable}, \
-                    {{{self.render(k)}: {self.render(v)} for k, v in {arg.data}.items()}})"
+                    {{{self.dict_key(k)}: {self.render(v)} for k, v in {arg.data}.items()}})"
         else:
             k = arg.key_field()
             v = arg.value_field()
-            return f"{{{self.render(k)}: {self.render(v)} for k, v in {arg.data}.items()}}"
+            return f"{{{self.dict_key(k)}: {self.render(v)} for k, v in {arg.data}.items()}}"
+
+    def dict_key(self, arg: DeField[Any]) -> str:
+        """
+        Render rvalue for a dict key.
+
+        Formats such as JSON/YAML stringify object keys, so an ``int``/``float`` key
+        arrives as e.g. ``"1"``/``"1.5"`` on deserialization. Coerce such keys back to
+        their declared numeric type even when coercion is otherwise suppressed (i.e.
+        ``strict``), mirroring how stringified ``IntEnum``/``IntFlag`` keys are handled.
+        ``bool`` is intentionally excluded because ``bool("false")`` is ``True``.
+        """
+        typ = arg.type
+        if (
+            isinstance(typ, type)
+            and issubclass(typ, (int, float))
+            and not issubclass(typ, bool)
+            and not is_enum(typ)
+        ):
+            return f'coerce_object("{self.class_name}", "k", {typename(typ)}, {arg.data})'
+        return self.render(arg)
 
     def enum(self, arg: DeField[Any]) -> str:
         # Pass the raw data to ``deserialize_enum``, which constructs the enum

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -262,6 +262,23 @@ def test_dict_with_int_enum_keys(se: Any, de: Any, opt: Any) -> None:
         assert p == de(Foo, se(p))
 
 
+@pytest.mark.parametrize("opt", opt_case, ids=opt_case_ids())
+@pytest.mark.parametrize("se,de", all_formats)
+def test_dict_with_numeric_keys(se: Any, de: Any, opt: Any) -> None:
+    @serde.serde(**opt)
+    class Foo:
+        i: dict[int, str]
+        f: dict[float, str]
+
+    # Msgpack and Toml can not represent non string keys.
+    if se not in (serde.msgpack.to_msgpack, serde.toml.to_toml):
+        # Formats such as JSON stringify object keys, so an int/float key arrives
+        # as e.g. "1"/"1.5" on deserialization. It must still round-trip back to
+        # the numeric key.
+        p = Foo({1: "a", 2: "b"}, {1.5: "x", 2.0: "y"})
+        assert p == de(Foo, se(p))
+
+
 def test_deserialize_enum_helper() -> None:
     from serde.core import deserialize_enum
 

--- a/tests/test_de.py
+++ b/tests/test_de.py
@@ -29,6 +29,25 @@ def test_from_obj() -> None:
     assert isinstance(dec[1], Decimal) and dec[1] == Decimal(0.1)
 
 
+def test_from_obj_dict() -> None:
+    import collections
+    from typing import Dict, DefaultDict
+
+    # Bare dict is returned as-is. Use ``typing.Dict`` so ``from_obj`` does not
+    # short-circuit on the ``type(o) is c`` early return and actually reaches the
+    # dict handling.
+    assert {"a": 1, "b": 2} == from_obj(Dict, {"a": 1, "b": 2}, False, False)
+
+    # Regular dict coerces both keys and values to the declared types.
+    assert {1: "a", 2: "b"} == from_obj(dict[int, str], {"1": "a", "2": "b"}, False, False)
+    assert {"a": 1} == from_obj(dict[str, int], {"a": "1"}, False, False)
+
+    # DefaultDict yields a collections.defaultdict with coerced keys/values.
+    dd = from_obj(DefaultDict[int, str], {"1": "a"}, False, False)
+    assert isinstance(dd, collections.defaultdict)
+    assert dd == {1: "a"}
+
+
 kwargs = (
     "maybe_generic=maybe_generic, maybe_generic_type_vars=maybe_generic_type_vars, "
     "variable_type_args=None, reuse_instances=reuse_instances, "


### PR DESCRIPTION
A dataclass with a `dict[int, V]` or `dict[float, V]` field serializes to JSON fine, but can't be deserialized back:

```python
@serde
@dataclass
class Foo:
    d: dict[int, str]

from_json(Foo, to_json(Foo({1: "a"})))
# SerdeError: ... dict key str '1' not instance of int
```

JSON stringifies object keys, so the key arrives as `"1"` (or `"1.5"` for floats) and the strict type check / float number guard rejects it, even though `from_json(to_json(obj)) == obj` should hold. YAML and `to_dict`/`from_dict` already round-trip these fine, and `dict[IntEnum, V]` keys were recently fixed for JSON too, so plain numeric keys were the odd ones out.

This coerces stringified numeric dict keys back to their declared type when rendering the deserializer, mirroring the existing IntEnum/IntFlag key handling. `bool` is intentionally left out since `bool("false")` is `True`. msgpack/toml are unchanged (they can't represent non-string keys at the format level).

Added a round-trip test covering `dict[int, str]` and `dict[float, str]`; it fails before the change and passes after. Full test suite is green.