### PR TITLE
Reduce from_obj complexity

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -492,6 +492,51 @@ def _deserialize_optional(
     return deserializer(type_args(c)[0], o)
 
 
+_UNHANDLED = object()
+
+
+def _from_obj_collection(
+    c: Any,
+    o: Any,
+    thisfunc: Callable[[Any, Any], Any],
+) -> Any:
+    if is_list(c):
+        if is_bare_list(c):
+            return list(o)
+        return [thisfunc(type_args(c)[0], e) for e in o]
+    if is_set(c):
+        if is_bare_set(c):
+            return set(o)
+        if is_frozen_set(c):
+            return frozenset(thisfunc(type_args(c)[0], e) for e in o)
+        return {thisfunc(type_args(c)[0], e) for e in o}
+    if is_deque(c):
+        if is_bare_deque(c):
+            return collections.deque(o)
+        return collections.deque(thisfunc(type_args(c)[0], e) for e in o)
+    if is_counter(c):
+        if is_bare_counter(c):
+            return collections.Counter(o)
+        return collections.Counter({thisfunc(type_args(c)[0], k): v for k, v in o.items()})
+    if is_tuple(c):
+        if is_bare_tuple(c) or is_variable_tuple(c):
+            return tuple(e for e in o)
+        return tuple(thisfunc(type_args(c)[i], e) for i, e in enumerate(o))
+    if is_dict(c):
+        if is_bare_dict(c):
+            return o
+        if is_default_dict(c):
+            f = DeField(c, "")
+            v = f.value_field()
+            origin = get_origin(v.type)
+            return collections.defaultdict(
+                origin if origin else v.type,
+                {thisfunc(type_args(c)[0], k): thisfunc(type_args(c)[1], v) for k, v in o.items()},
+            )
+        return {thisfunc(type_args(c)[0], k): thisfunc(type_args(c)[1], v) for k, v in o.items()}
+    return _UNHANDLED
+
+
 def from_obj(
     c: type[T],
     o: Any,
@@ -567,51 +612,8 @@ def from_obj(
             res = deserializable_to_obj(c)
         elif is_opt(c):
             res = _deserialize_optional(c, o, thisfunc)
-        elif is_list(c):
-            if is_bare_list(c):
-                res = list(o)
-            else:
-                res = [thisfunc(type_args(c)[0], e) for e in o]
-        elif is_set(c):
-            if is_bare_set(c):
-                res = set(o)
-            elif is_frozen_set(c):
-                res = frozenset(thisfunc(type_args(c)[0], e) for e in o)
-            else:
-                res = {thisfunc(type_args(c)[0], e) for e in o}
-        elif is_deque(c):
-            if is_bare_deque(c):
-                res = collections.deque(o)
-            else:
-                res = collections.deque(thisfunc(type_args(c)[0], e) for e in o)
-        elif is_counter(c):
-            if is_bare_counter(c):
-                res = collections.Counter(o)
-            else:
-                res = collections.Counter({thisfunc(type_args(c)[0], k): v for k, v in o.items()})
-        elif is_tuple(c):
-            if is_bare_tuple(c) or is_variable_tuple(c):
-                res = tuple(e for e in o)
-            else:
-                res = tuple(thisfunc(type_args(c)[i], e) for i, e in enumerate(o))
-        elif is_dict(c):
-            if is_bare_dict(c):
-                res = o
-            elif is_default_dict(c):
-                f = DeField(c, "")
-                v = f.value_field()
-                origin = get_origin(v.type)
-                res = collections.defaultdict(
-                    origin if origin else v.type,
-                    {
-                        thisfunc(type_args(c)[0], k): thisfunc(type_args(c)[1], v)
-                        for k, v in o.items()
-                    },
-                )
-            else:
-                res = {
-                    thisfunc(type_args(c)[0], k): thisfunc(type_args(c)[1], v) for k, v in o.items()
-                }
+        elif (collection_res := _from_obj_collection(c, o, thisfunc)) is not _UNHANDLED:
+            res = collection_res
         elif _is_numpy_array(c):
             from .numpy import deserialize_numpy_array_direct
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -351,6 +351,7 @@ def test_deserialize_enum_helper_heterogeneous() -> None:
 
     # list->tuple must fire even though the first member is not a tuple.
     assert deserialize_enum(Mixed, ["x", "y"]) is Mixed.PAIR
+
     # str->numeric must fire even though the first member's value is not numeric.
     class Mixed2(enum.Enum):
         NAME = "alice"  # first member: value type is str


### PR DESCRIPTION
## Summary
- move the collection branches from `from_obj` into a private helper
- keep the existing deserialization order and error wrapping intact
- fix the current Ruff C901 failure on `serde/de.py`

This also addresses the formatting check failure currently blocking #765.

## Verification
- `UV_FROZEN=1 uv run --frozen ruff check --force-exclude serde/de.py`
- `UV_FROZEN=1 make check`
- `UV_FROZEN=1 make test`
- `UV_FROZEN=1 make examples`

AI assistance was used under my direction.