### PR TITLE
Fix Claude code review workflow to skip fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip PRs from forks: fork-triggered `pull_request` runs don't receive an
+    # OIDC token or repository secrets, so the action can't authenticate and the
+    # job always fails. Only run for branches pushed to this repository.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
Updated the Claude code review workflow to prevent job failures when triggered by pull requests from forks, which lack access to OIDC tokens and repository secrets needed for authentication.

## Changes
- Replaced commented-out author-based filtering logic with a repository check condition
- Added `if: github.event.pull_request.head.repo.full_name == github.repository` to ensure the workflow only runs for branches pushed to the main repository
- Updated inline comments to explain why fork PRs must be skipped and the authentication limitations they face

## Details
Fork-triggered `pull_request` events in GitHub Actions don't receive OIDC tokens or access to repository secrets, causing the code review action to fail during authentication. This change ensures the workflow only executes for PRs from branches in the repository itself, where proper credentials are available.

https://claude.ai/code/session_01Y6SbJs4shnmKZTMs1CdRoc