### PR TITLE
Fix alias for non-primitive fields

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -835,6 +835,9 @@ class DeField(Field[T]):
         e.g. Optional
             * datavar property returns "data"
             * data property returns "data.get("field_name")".
+        e.g. a field with an alias
+            * datavar property returns "data"
+            * data property returns "_get_by_aliases(data, ["field_name", ...])".
         For other types
             * datavar property returns "data"
             * data property returns "data["field_name"]".
@@ -842,7 +845,17 @@ class DeField(Field[T]):
 
         if self.iterbased:
             return f"{self.datavar}[{self.index}]"
-        elif is_union(self.type) and type(None) in get_args(self.type):
+        optional = is_union(self.type) and type(None) in get_args(self.type)
+        if self.alias:
+            # A field may be populated from any of its aliases (or its own name),
+            # so read it through ``_get_by_aliases`` regardless of the field type.
+            # This keeps ``alias`` working for containers, datetimes, nested
+            # dataclasses etc. - not just the leaf renderers (primitive/enum/
+            # Optional) that used to special-case it.
+            names = ", ".join(f'"{name}"' for name in [self.name, *self.alias])
+            raise_error = "False" if optional else "True"
+            return f"_get_by_aliases({self.datavar}, [{names}], raise_error={raise_error})"
+        elif optional:
             return f'{self.datavar}.get("{self.conv_name()}")'
         else:
             return f'{self.datavar}["{self.conv_name()}"]'
@@ -1191,11 +1204,7 @@ class Renderer:
         # member itself. Coercing the value beforehand (e.g. via ``coerce_object``)
         # would eagerly call ``EnumType(value)`` and fail for stringified keys of
         # ``IntEnum``/``IntFlag`` produced by JSON (e.g. ``"1"``).
-        dat = arg.data
-        if arg.alias:
-            aliases = (f'"{s}"' for s in [arg.name, *arg.alias])
-            dat = f"_get_by_aliases(data, [{','.join(aliases)}])"
-        return f"deserialize_enum({typename(arg.type)}, {dat})"
+        return f"deserialize_enum({typename(arg.type)}, {arg.data})"
 
     def primitive(self, arg: DeField[Any], suppress_coerce: bool = False) -> str:
         """
@@ -1205,9 +1214,6 @@ class Renderer:
         """
         typ = typename(arg.type)
         dat = arg.data
-        if arg.alias:
-            aliases = (f'"{s}"' for s in [arg.name, *arg.alias])
-            dat = f"_get_by_aliases(data, [{','.join(aliases)}])"
         if isinstance(arg.type, type) and issubclass(arg.type, float):
             if self.suppress_coerce and suppress_coerce:
                 return f"deserialize_numbers({dat}) if deserialize_numbers else {dat}"

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -746,6 +746,79 @@ def test_default_rename_and_alias() -> None:
     assert ff.a == 2
 
 
+def test_alias_with_list() -> None:
+    @serde.serde
+    class Foo:
+        a: list[int] = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    assert Foo([1, 2]) == serde.json.from_json(Foo, '{"a":[1,2]}')
+    assert Foo([1, 2]) == serde.json.from_json(Foo, '{"b":[1,2]}')
+
+
+def test_alias_with_optional_list_default() -> None:
+    @serde.serde
+    class Foo:
+        a: Optional[list[int]] = serde.field(alias=["b"], default=None)  # type: ignore[literal-required]
+
+    assert Foo([1]) == serde.json.from_json(Foo, '{"b":[1]}')
+    assert Foo(None) == serde.json.from_json(Foo, "{}")
+
+
+def test_alias_with_list_default_factory() -> None:
+    @serde.serde
+    class Foo:
+        a: list[int] = serde.field(alias=["b"], default_factory=list)  # type: ignore[literal-required]
+
+    assert Foo([1]) == serde.json.from_json(Foo, '{"b":[1]}')
+    assert Foo([]) == serde.json.from_json(Foo, "{}")
+
+
+def test_alias_with_dict() -> None:
+    @serde.serde
+    class Foo:
+        a: dict[str, int] = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    assert Foo({"x": 1}) == serde.json.from_json(Foo, '{"b":{"x":1}}')
+
+
+def test_alias_with_set() -> None:
+    @serde.serde
+    class Foo:
+        a: set[int] = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    assert Foo({1, 2}) == serde.json.from_json(Foo, '{"b":[1,2]}')
+
+
+def test_alias_with_tuple() -> None:
+    @serde.serde
+    class Foo:
+        a: tuple[int, str] = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    assert Foo((1, "x")) == serde.json.from_json(Foo, '{"b":[1,"x"]}')
+
+
+def test_alias_with_datetime() -> None:
+    @serde.serde
+    class Foo:
+        a: datetime.datetime = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    dt = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    assert Foo(dt) == serde.json.from_json(Foo, '{"b":"2021-01-01T00:00:00"}')
+
+
+def test_alias_with_nested_dataclass() -> None:
+    @serde.serde
+    class Bar:
+        e: int
+        f: str
+
+    @serde.serde
+    class Foo:
+        a: Bar = serde.field(alias=["b"])  # type: ignore[literal-required]
+
+    assert Foo(Bar(1, "x")) == serde.json.from_json(Foo, '{"b":{"e":1,"f":"x"}}')
+
+
 def test_skip() -> None:
     # Note that skipped field is not the last one
     @serde.serde


### PR DESCRIPTION
Deserializing a field with an `alias` only worked when the field was a primitive, enum or `Optional`. For any other type it failed. The two snippets from #432 are the clearest example:

```python
@serde
@dataclass
class Foo:
    a: Optional[list[int]] = field(alias=["b"], default=None)

from_json(Foo, '{"b": [1]}')  # SerdeError: missing required field 'a'
```

The generated deserializer read `data["a"]` directly, so any aliased key was ignored for lists, sets, dicts, tuples, datetimes, `Decimal`, nested dataclasses, etc. A `tuple` alias was worse — the alias leaked into the element fields and produced invalid generated code, so the class couldn't even be defined.

The alias handling was duplicated in a couple of leaf renderers (`primitive`, `enum`) instead of living where the value is actually read. I moved it into `DeField.data`, so every renderer resolves the value through `_get_by_aliases`, and removed the now-redundant per-renderer handling. `Optional` already worked and still does.

Added tests covering the two cases from the issue plus list/set/dict/tuple/datetime and a nested dataclass (the case @kaiaw raised in the thread).

Fixes #432