### PR TITLE
Fix Enum deserialization for heterogeneous enums

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -1157,14 +1157,25 @@ def deserialize_enum(typ: type[enum.Enum], value: Any) -> enum.Enum:
     try:
         return typ(value)
     except (ValueError, KeyError):
-        # A ValueError/KeyError here means ``typ`` has at least one member (an
-        # empty enum would raise TypeError instead), so ``__members__`` is never
-        # empty in this branch.
-        member_value_type = type(next(iter(typ.__members__.values())).value)
-        if isinstance(value, list) and member_value_type is tuple:
-            return typ(tuple(value))
-        if isinstance(value, str) and member_value_type is not str:
-            return typ(member_value_type(value))
+        # JSON/YAML coerce enum values used as object keys to ``str`` and turn
+        # tuple values into ``list``. Retry after undoing that coercion. The enum
+        # may be heterogeneous, so derive the conversion from ``value`` itself
+        # rather than assuming every member shares the first member's value type.
+        if isinstance(value, list):
+            # A ``list`` can only originate from a tuple-valued member: list
+            # values are unhashable and are never valid enum values.
+            try:
+                return typ(tuple(value))
+            except (ValueError, KeyError):
+                pass
+        elif isinstance(value, str):
+            for member_value_type in {type(member.value) for member in typ}:
+                if member_value_type is str:
+                    continue
+                try:
+                    return typ(member_value_type(value))
+                except (ValueError, KeyError, TypeError):
+                    continue
         raise
 
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -339,6 +339,65 @@ def test_enum_with_tuple_value(se: Any, de: Any) -> None:
     assert de(COpt, se(COpt(None))) == COpt(None)
 
 
+def test_deserialize_enum_helper_heterogeneous() -> None:
+    from serde.core import deserialize_enum
+
+    # An enum may mix value types. The conversion must be derived from the
+    # incoming value, not from the first member's value type.
+    class Mixed(enum.Enum):
+        NUM = 1  # first member: value type is int
+        TXT = "b"
+        PAIR = ("x", "y")  # tuple-valued member, not first
+
+    # list->tuple must fire even though the first member is not a tuple.
+    assert deserialize_enum(Mixed, ["x", "y"]) is Mixed.PAIR
+    # str->numeric must fire even though the first member's value is not numeric.
+    class Mixed2(enum.Enum):
+        NAME = "alice"  # first member: value type is str
+        AGE = 30  # numeric member, not first
+
+    assert deserialize_enum(Mixed2, "30") is Mixed2.AGE
+    # Invalid values still re-raise for every branch.
+    with pytest.raises((ValueError, KeyError)):
+        deserialize_enum(Mixed, ["p", "q"])
+    with pytest.raises((ValueError, KeyError)):
+        deserialize_enum(Mixed2, "99")
+
+
+@pytest.mark.parametrize("se,de", (format_dict + format_json + format_yaml))
+def test_enum_heterogeneous_tuple_member(se: Any, de: Any) -> None:
+    # Regression: a tuple-valued member that is not the first member serializes
+    # to a list and previously failed to deserialize (the member value type was
+    # sampled from the first member only).
+    class Mixed(enum.Enum):
+        NUM = 1
+        TXT = "b"
+        PAIR = ("x", "y")
+
+    @serde.serde
+    class C:
+        m: Mixed
+
+    for member in Mixed:
+        assert de(C, se(C(member))) == C(member)
+
+
+@pytest.mark.parametrize("se,de", (format_dict + format_json + format_yaml))
+def test_enum_heterogeneous_numeric_key(se: Any, de: Any) -> None:
+    # Regression: a numeric member that is not the first member arrives as a
+    # stringified dict key and previously failed to coerce back (the member
+    # value type was sampled from the first member only).
+    class Mixed(enum.Enum):
+        NAME = "alice"
+        AGE = 30
+
+    @serde.serde
+    class C:
+        d: dict[Mixed, int]
+
+    assert de(C, se(C({Mixed.AGE: 1}))) == C({Mixed.AGE: 1})
+
+
 @pytest.mark.parametrize("se,de", (format_dict + format_json + format_yaml))
 def test_aliased_enum_field(se: Any, de: Any) -> None:
     class IE(enum.IntEnum):


### PR DESCRIPTION
`deserialize_enum()` samples the enum's value type from only the first member:

```python
member_value_type = type(next(iter(typ.__members__.values())).value)
if isinstance(value, list) and member_value_type is tuple: ...
if isinstance(value, str) and member_value_type is not str: ...
```

Enums may mix value types, and the relevant member is not always first. When it isn't, both JSON/YAML coercion fallbacks misfire and a value that serialized fine fails to deserialize on the round trip:

```python
import enum
from serde.core import deserialize_enum

class Mixed(enum.Enum):
    NUM = 1            # first member: value type sampled as int
    TXT = "b"
    PAIR = ("x", "y")  # tuple-valued member, not first

# to_json(Mixed.PAIR) produces the list ["x", "y"]; deserializing it back:
deserialize_enum(Mixed, ["x", "y"])
# ValueError: ['x', 'y'] is not a valid Mixed   (expected Mixed.PAIR)
```

A numeric member that is not first fails the same way when used as a dict key: it arrives stringified (e.g. `"30"`), but the sampled type is `str`, so no coercion happens.

This is issue #585; the recently merged #765 fixed only the homogeneous case.

The fix derives the coercion from the incoming `value` itself instead of assuming every member shares the first member's value type: a `list` is retried as a `tuple`, and a `str` is retried against the enum's non-`str` member value types. It is purely additive (the new branches run only in the `except` path that previously re-raised), so no existing test changes and the full suite stays green.

Added regression tests following the existing `test_enum_with_tuple_value` convention: a direct `deserialize_enum` helper test plus parametrized json/yaml/dict round-trips for a not-first tuple member and a not-first numeric dict key.

Fixes #585
