### PR TITLE
Fix nested generic dataclass deserialization (#464)

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -1153,9 +1153,18 @@ def get_generic_arg(
     'str'
     >>> get_generic_arg(GenericFoo[int, str], ['T', 'U'], ['U'], 0).__name__
     'str'
+    >>> get_generic_arg(GenericFoo[int, str], ['T', 'U'], None, 0).__name__
+    'int'
     """
-    if not is_generic(typ) or maybe_generic_type_vars is None or variable_type_args is None:
+    if not is_generic(typ) or maybe_generic_type_vars is None:
         return typing.Any
+
+    if variable_type_args is None:
+        # No remapping was supplied by the caller (e.g. when deserializing directly
+        # into a subscripted generic such as ``Foo[Bar[int]]``). In that case the
+        # field's type var maps straight onto the class's own type vars, so fall back
+        # to the identity mapping instead of losing the argument. See issue #464.
+        variable_type_args = maybe_generic_type_vars
 
     args = get_args(typ)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -8,7 +8,9 @@ import datetime
 from beartype.roar import BeartypeCallHintViolation
 from typing import (
     ClassVar,
+    Generic,
     Optional,
+    TypeVar,
     Any,
 )
 from collections import defaultdict
@@ -1549,3 +1551,33 @@ def test_dict_str_any() -> None:
 
     assert serde.to_dict(foo) == foo_se
     assert serde.from_dict(Foo, foo_se) == foo_de
+
+
+def test_generic_with_generic_dataclass_arg() -> None:
+    # https://github.com/yukinarit/pyserde/issues/464
+    # Deserializing into a generic whose type argument is itself a generic
+    # dataclass (e.g. ``Foo[Bar[int]]``) used to leave the inner dataclass as a
+    # raw dict instead of reconstructing it.
+    T = TypeVar("T")
+
+    @serde.serde
+    class Bar(Generic[T]):
+        inner: T
+
+    @serde.serde
+    class Foo(Generic[T]):
+        inner: T
+
+    # A plain type argument keeps working.
+    f1 = Foo(10)
+    assert f1 == serde.json.from_json(Foo[int], serde.json.to_json(f1))
+
+    # A generic dataclass as the type argument is now reconstructed.
+    f2 = Foo(Bar(10))
+    json = serde.json.to_json(f2)
+    assert json == '{"inner":{"inner":10}}'
+    assert f2 == serde.json.from_json(Foo[Bar[int]], json)
+
+    # Nested more than one level deep also works.
+    f3 = Foo(Bar(Bar(10)))
+    assert f3 == serde.json.from_json(Foo[Bar[Bar[int]]], serde.json.to_json(f3))


### PR DESCRIPTION
Fixes #464

## Root cause

When deserializing directly into a subscripted generic whose type argument is itself a generic dataclass, e.g. `from_json(Foo[Bar[int]], ...)`, the inner dataclass was left as a raw `dict` instead of being reconstructed.

For a field typed as a bare `TypeVar` (`inner: T` in `Foo`), the generated deserializer resolves the type var at runtime via:

```python
from_obj(get_generic_arg(maybe_generic, maybe_generic_type_vars, variable_type_args, 0), data["inner"], ...)
```

`get_generic_arg` (in `serde/compat.py`) returned `typing.Any` whenever `variable_type_args` was `None`. That argument is only populated when a *nested dataclass field* is rendered (`Renderer.dataclass` passes `variable_type_args=...`). At the top-level entry point — `from_obj` → `deserializable_to_obj` → the generated `from_dict`/`from_iter` — it is never passed, so it stays `None`. As a result the field's `TypeVar` resolved to `Any`, and `from_obj(Any, {"inner": 10})` returned the raw dict unchanged.

## Reproduction

```python
from typing import Generic, TypeVar
from serde import serde
from serde.json import from_json, to_json

T = TypeVar("T")

@serde
class Bar(Generic[T]):
    inner: T

@serde
class Foo(Generic[T]):
    inner: T

f2 = Foo(Bar(10))
json = to_json(f2)          # {"inner":{"inner":10}}
print(from_json(Foo[Bar[int]], json))
```

Before this change the last line printed:

```
Foo(inner={'inner': 10})
```

(the inner `Bar` is a plain `dict`). With the fix it prints the expected:

```
Foo(inner=Bar(inner=10))
```

## Fix

In `get_generic_arg`, when `variable_type_args is None`, fall back to `maybe_generic_type_vars` — the identity mapping. This is exactly correct for the top-level case, where the field's type var maps straight onto the class's own type vars. When a remapping *is* supplied (nested dataclass fields, subclass type-var reordering), `variable_type_args` is non-`None` and behavior is unchanged, so the fix is localized to the previously-broken path.

The change is a single guard split plus a fallback assignment (7 lines) in one function; no other code paths are touched.

## Tests

Added `test_generic_with_generic_dataclass_arg` in `tests/test_basics.py`, which covers the plain type-argument case (already working), the `Foo[Bar[int]]` case from the issue, and one extra level of nesting (`Foo[Bar[Bar[int]]]`). Confirmed the new test fails on the unmodified code (inner value is a `dict`) and passes with the fix. Also added a doctest line for the new `variable_type_args=None` path.

The broad relevant suites pass locally (`test_basics`, `test_de`, `test_compat`, `test_union`, `test_json`, `test_core`, `test_se` — 4975 passed, 1 pre-existing skip), and `serde/compat.py` doctests pass. The only failures in the full run are pre-existing `tests/test_numpy.py` errors caused by a beartype/NumPy version mismatch in my local environment; they reproduce identically on unmodified `main`, unrelated to this change. `ruff` and `black` are clean on the changed lines.

Disclosure: prepared with AI assistance; reviewed and verified locally.
