### PR TITLE
Fix flatten on an optional dataclass field with a default

### DIFF
--- a/serde/de.py
+++ b/serde/de.py
@@ -1270,8 +1270,10 @@ class Renderer:
         if arg.flatten:
             # When a field has the `flatten` attribute, iterate over its dataclass fields.
             # This ensures that the code checks keys in the data while considering aliases.
+            # An optional flattened field holds the dataclass in its type argument.
+            inner = arg[0] if is_opt(arg.type) else arg
             flattened = []
-            for subarg in defields(arg.type):
+            for subarg in defields(inner.type):
                 if subarg.alias:
                     aliases = get_aliased_fields(subarg)
                     flattened.append(f"_exists_by_aliases({arg.datavar}, [{','.join(aliases)}])")

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -92,6 +92,25 @@ def test_flatten_optional(se: Any, de: Any) -> None:
 
 
 @pytest.mark.parametrize("se,de", all_formats)
+def test_flatten_optional_with_default(se: Any, de: Any) -> None:
+    @serde
+    class Bar:
+        c: float
+        d: bool
+
+    @serde
+    class Foo:
+        a: int
+        b: str
+        bar: Optional[Bar] = field(default=None, flatten=True)
+
+    f = Foo(a=10, b="foo", bar=Bar(c=100.0, d=True))
+    assert de(Foo, se(f)) == f
+
+    assert from_dict(Foo, {"a": 10, "b": "foo"}) == Foo(a=10, b="foo", bar=None)
+
+
+@pytest.mark.parametrize("se,de", all_formats)
 def test_flatten_not_supported(se: Any, de: Any) -> None:
     @serde
     class Bar:


### PR DESCRIPTION
Marking a flattened dataclass field optional *and* giving it a default blows up at decoration time:

```python
@serde
class Bar:
    c: float
    d: bool

@serde
class Foo:
    a: int
    bar: Optional[Bar] = field(default=None, flatten=True)
# AttributeError: __serde__
```

Either attribute alone is fine — `Optional[Bar] = field(flatten=True)` works (#542) and `Bar = field(flatten=True, default_factory=Bar)` works (#612) — it's only the combination that breaks, which is a shame because `default=None` is the natural thing to write on an optional flattened sub-struct.

`Renderer.default` builds the "are the flattened keys present?" check by iterating the field's own dataclass fields, but for an optional field the type is `Optional[Bar]`, not `Bar`, so `defields()` goes looking for `__serde__` on a typing object. `Renderer.opt` already unwraps the optional before reading the inner fields, so I did the same thing here.

Tested with a new case next to `test_flatten_optional` covering all formats, plus the missing-key path so the `None` default is actually exercised. It fails on main across all seven formats and passes with the fix; `make test` is green.

One thing worth flagging: `make check` currently fails `black` on `tests/test_basics.py`, which is untouched by this PR — it reformats on a clean checkout of main too, so I left it alone rather than mixing it in here.