### PR TITLE
fix: serialize bare enum members and enum dict keys

### DIFF
--- a/serde/se.py
+++ b/serde/se.py
@@ -430,6 +430,8 @@ def to_obj(
         class_serializer = find_global_class_serializer(type(o))
         if class_serializer is not None:
             return class_serializer.serialize(o)
+        if is_enum(type(o)):
+            return enum_value(type(o), o)
         if is_dataclass_without_se(o):
             # Do not automatically implement beartype if dataclass without serde decorator
             # is passed, because it is surprising for users
@@ -443,7 +445,7 @@ def to_obj(
         elif is_bearable(o, tuple):  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             return tuple(thisfunc(e) for e in o)
         elif isinstance(o, Mapping):
-            return {k: thisfunc(v) for k, v in o.items()}
+            return {thisfunc(k): thisfunc(v) for k, v in o.items()}
         elif isinstance(o, Set):
             return [thisfunc(e) for e in o]
         elif isinstance(o, deque):

--- a/tests/test_se.py
+++ b/tests/test_se.py
@@ -1,3 +1,4 @@
+import enum
 from collections.abc import Sequence, MutableSequence
 
 from serde import asdict, astuple, serialize, to_dict, to_tuple
@@ -192,3 +193,12 @@ def test_render_dataclass() -> None:
     rendered = Renderer(TO_ITER).render(SeField(Foo, "foo"))
     rendered_foo = f"foo.__serde__.funcs['to_iter'](foo, {kwargs})"
     assert rendered_foo == rendered
+
+
+def test_to_json_bare_enum_and_enum_dict_key() -> None:
+    class E(enum.Enum):
+        FOO = "foo"
+
+    assert to_json(E.FOO) == '"foo"'
+    assert to_json([E.FOO]) == '["foo"]'
+    assert to_json({E.FOO: "x"}) == '{"foo":"x"}'


### PR DESCRIPTION
Closes #468

`to_obj()` has no enum branch, so an `Enum` member reaches the backend serializer unconverted: `to_json(MyEnum.FOO)` and an enum used as a dict key both raise `TypeError` from `json.dumps`. Mapping values were converted recursively but keys were passed through untouched.

Fixed by converting enum instances with the existing `enum_value()` helper and applying the recursive conversion to mapping keys as well as values. New test in `tests/test_se.py` fails without the change and passes with it; full suite 5246 passed.
