### PR TITLE
Add custom coercer API

### DIFF
--- a/docs/en/type-check.md
+++ b/docs/en/type-check.md
@@ -69,6 +69,56 @@ foo = Foo(10)
 print(to_json(foo))
 ```
 
+### Custom coercion rules
+
+By default, `coerce` converts a primitive value by calling its declared type, as in `int(value)`.
+To validate values or use a different conversion, pass a coercer function to
+`coerce(coercer=...)`. The function receives:
+
+- `owner`: the decorated class name, such as `"Config"`, or `None` when unavailable
+- `field`: the field name, such as `"count"`
+- `target`: the declared primitive type
+- `value`: the value to convert
+
+The function must return the converted value. If it raises an exception, pyserde wraps that
+exception in `SerdeError`.
+
+The following function accepts only integer values for `int` fields. It includes the field location
+in the error message and converts all other primitive types normally:
+
+```python
+from typing import Any
+from serde import coerce, from_dict, serde
+
+
+def integer_only(
+    owner: str | None, field: str, target: type[Any], value: Any
+) -> Any:
+    if target is int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            location = f"{owner}.{field}" if owner else field
+            raise TypeError(f"{location} must be an integer")
+    return target(value)
+
+
+@serde(type_check=coerce(coercer=integer_only))
+class Config:
+    count: int
+
+
+from_dict(Config, {"count": 1})       # Config(count=1)
+from_dict(Config, {"count": 1.5})     # raises SerdeError mentioning Config.count
+```
+
+pyserde calls the function for primitive fields during both serialization and deserialization,
+including primitive values inside containers and `Optional` fields. Enums and `Literal` values are
+not passed to the function, nor is the function used to select a `Union` branch. Field serializers
+and deserializers handle their corresponding direction without invoking it. The `field` argument is
+`"v"` for list items and mapping values, and `"k"` for mapping keys.
+
+The function is configured per class. Fields in a nested dataclass are therefore handled according
+to that dataclass's own `type_check` setting.
+
 ## `disabled`
 
 This is the default behavior until pyserde v0.8.3 and v0.9.x. No type coercion or checks are run. Even if a user puts a wrong value, pyserde doesn't complain anything.

--- a/docs/ja/type-check.md
+++ b/docs/ja/type-check.md
@@ -76,6 +76,47 @@ print(to_json(foo))
 
 しかし、値が宣言された型に変換できない場合（例えば、値が `foo` で型が `int` の場合）、pyserde は`SerdeError` を発生させます。
 
+### 変換ルールをカスタマイズする
+
+`coerce` は通常、`int(value)` のように宣言された型を呼び出してプリミティブ値を変換します。入力値を検証したり、別の方法で変換したりするには、`coerce(coercer=...)` に coercer 関数を渡します。この関数は次の引数を受け取ります。
+
+- `owner`: `"Config"` のようなデコレートされたクラス名。クラス名を取得できない場合は `None`
+- `field`: `"count"` のようなフィールド名
+- `target`: 宣言されたプリミティブ型
+- `value`: 変換する値
+
+関数は変換後の値を返す必要があります。関数から例外が送出されると、pyserde はその例外を `SerdeError` でラップします。
+
+次の関数は、`int` フィールドでは整数値だけを受け入れます。エラーメッセージにはフィールドの場所を含め、その他のプリミティブ型は通常どおり変換します。
+
+```python
+from typing import Any
+from serde import coerce, from_dict, serde
+
+
+def integer_only(
+    owner: str | None, field: str, target: type[Any], value: Any
+) -> Any:
+    if target is int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            location = f"{owner}.{field}" if owner else field
+            raise TypeError(f"{location} は整数である必要があります")
+    return target(value)
+
+
+@serde(type_check=coerce(coercer=integer_only))
+class Config:
+    count: int
+
+
+from_dict(Config, {"count": 1})       # Config(count=1)
+from_dict(Config, {"count": 1.5})     # Config.count を含む SerdeError を送出
+```
+
+pyserde は、シリアライズとデシリアライズのどちらでも、プリミティブ型のフィールドにこの関数を使用します。コンテナや `Optional` 内のプリミティブ値も対象です。列挙型や `Literal` の値がこの関数に渡されることはなく、`Union` の分岐選択にも使われません。フィールドシリアライザまたはフィールドデシリアライザを指定すると、対応する処理ではこの関数は呼び出されません。リストの要素とマッピングの値では `field` に `"v"`、マッピングのキーでは `"k"` が渡されます。
+
+この関数はクラスごとに設定されます。そのため、ネストしたデータクラスのフィールドには、そのデータクラス自身の `type_check` 設定が適用されます。
+
 ## `disabled`
 
 これはpyserde v0.8.3およびv0.9.xまでのデフォルトの挙動です。  

--- a/serde/core.py
+++ b/serde/core.py
@@ -1109,6 +1109,10 @@ def should_impl_dataclass(cls: type[Any]) -> bool:
     return False
 
 
+Coercer = Callable[[str | None, str, type[Any], Any], Any]
+"""Convert a field value into its declared primitive type."""
+
+
 @dataclass
 class TypeCheck:
     """
@@ -1125,6 +1129,7 @@ class TypeCheck:
         """ Value are strictly checked against the declared type """
 
     kind: Kind
+    coercer: Coercer | None = None
 
     def is_strict(self) -> bool:
         return self.kind == self.Kind.Strict
@@ -1132,9 +1137,20 @@ class TypeCheck:
     def is_coerce(self) -> bool:
         return self.kind == self.Kind.Coerce
 
-    def __call__(self, **kwargs: Any) -> TypeCheck:
-        # TODO
-        return self
+    def __call__(self, *, coercer: Coercer | None = None) -> TypeCheck:
+        """
+        Return a type-check configuration with an optional custom coercer.
+
+        Only ``coerce`` accepts a custom coercer. Calling ``coerce()`` without
+        one preserves the shared default configuration.
+        """
+        if coercer is None:
+            return self
+        if not self.is_coerce():
+            raise TypeError("A custom coercer is only supported by serde.coerce.")
+        if not callable(coercer):
+            raise TypeError("coercer must be callable.")
+        return dataclasses.replace(self, coercer=coercer)
 
 
 disabled = TypeCheck(kind=TypeCheck.Kind.Disabled)
@@ -1179,14 +1195,16 @@ def deserialize_enum(typ: type[enum.Enum], value: Any) -> enum.Enum:
         raise
 
 
-def coerce_object(cls: str, field: str, typ: type[Any], obj: Any) -> Any:
+def coerce_object(
+    cls: str | None, field: str, typ: type[Any], obj: Any, *, coercer: Coercer | None = None
+) -> Any:
     if obj is None:
         raise SerdeError(
             f"failed to coerce the field {cls}.{field} value {obj} into {typename(typ)}: "
             "None is not allowed for non-optional fields"
         )
     try:
-        return typ(obj)
+        return coercer(cls, field, typ, obj) if coercer else typ(obj)
     except Exception as e:
         raise SerdeError(
             f"failed to coerce the field {cls}.{field} value {obj} into {typename(typ)}: {e}"

--- a/serde/de.py
+++ b/serde/de.py
@@ -323,7 +323,11 @@ def deserialize(
         g["is_instance"] = is_instance
         g["TypeCheck"] = TypeCheck
         g["disabled"] = disabled
-        g["coerce_object"] = coerce_object
+        g["coerce_object"] = (
+            functools.partial(coerce_object, coercer=type_check.coercer)
+            if type_check.coercer
+            else coerce_object
+        )
         g["deserialize_enum"] = deserialize_enum
         g["_exists_by_aliases"] = _exists_by_aliases
         g["_get_by_aliases"] = _get_by_aliases

--- a/serde/se.py
+++ b/serde/se.py
@@ -280,7 +280,11 @@ def serialize(
         g["Literal"] = Literal
         g["TypeCheck"] = TypeCheck
         g["disabled"] = disabled
-        g["coerce_object"] = coerce_object
+        g["coerce_object"] = (
+            functools.partial(coerce_object, coercer=type_check.coercer)
+            if type_check.coercer
+            else coerce_object
+        )
         g["class_serializers"] = class_serializers
         if serializer:
             g["serde_legacy_custom_class_serializer"] = functools.partial(

--- a/tests/test_type_check.py
+++ b/tests/test_type_check.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from dataclasses import dataclass
 import datetime
 import pathlib
@@ -196,3 +197,227 @@ def test_coerce() -> None:
 
     f = InnerTuple(foo=(1, 2))
     assert f.foo == (1.0, 2.0)
+
+
+def _integer_only_coercer(
+    _owner: str | None, _field_name: str, target: type[Any], value: Any
+) -> Any:
+    if target is int and (isinstance(value, bool) or not isinstance(value, int)):
+        raise TypeError("expected an integer")
+    return target(value)
+
+
+def test_custom_coercer_configuration_is_isolated() -> None:
+    calls: list[tuple[str | None, str, type[Any], Any]] = []
+
+    def record_context(owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        calls.append((owner, field_name, target, value))
+        return target(value)
+
+    default_coerce = serde.coerce()
+    assert default_coerce is serde.coerce
+
+    @serde.serde(type_check=serde.coerce(coercer=record_context))
+    class CustomConfig:
+        value: int
+
+    @serde.serde(type_check=default_coerce)
+    class DefaultConfig:
+        value: int
+
+    assert serde.from_dict(CustomConfig, {"value": "1"}) == CustomConfig(1)
+    assert calls == [("CustomConfig", "value", int, "1")]
+
+    calls.clear()
+    assert serde.from_dict(DefaultConfig, {"value": "2"}) == DefaultConfig(2)
+    assert calls == []
+
+
+def test_custom_coercer_configuration_validation() -> None:
+    def coercer(_owner: str | None, _field_name: str, target: type[Any], value: Any) -> Any:
+        return target(value)
+
+    with pytest.raises(TypeError, match="only supported"):
+        serde.strict(coercer=coercer)
+    with pytest.raises(TypeError, match="must be callable"):
+        serde.coerce(coercer=42)  # type: ignore[arg-type]
+
+
+def test_custom_coercer_receives_field_context() -> None:
+    calls: list[tuple[str | None, str, type[Any], Any]] = []
+
+    def record_context(owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        calls.append((owner, field_name, target, value))
+        return target(value)
+
+    @serde.serde(type_check=serde.coerce(coercer=record_context))
+    class Config:
+        count: int
+
+    assert serde.from_dict(Config, {"count": "1"}) == Config(1)
+    assert calls == [("Config", "count", int, "1")]
+
+    calls.clear()
+    assert serde.to_dict(Config("2")) == {"count": 2}  # type: ignore[arg-type]
+    assert calls == [("Config", "count", int, "2")]
+
+
+def test_custom_coercer_receives_composite_value_context() -> None:
+    calls: list[tuple[str | None, str, type[Any], Any]] = []
+
+    def record_context(owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        calls.append((owner, field_name, target, value))
+        return target(value)
+
+    @serde.serde(type_check=serde.coerce(coercer=record_context))
+    class Payload:
+        values: list[float]
+        mapping: dict[int, str]
+
+    payload = serde.from_dict(
+        Payload,
+        {"values": [2, 3.5], "mapping": {"5": 6}},
+    )
+    assert payload == Payload([2.0, 3.5], {5: "6"})
+    assert Counter(calls) == Counter(
+        [
+            ("Payload", "v", float, 2),
+            ("Payload", "v", float, 3.5),
+            ("Payload", "k", int, "5"),
+            ("Payload", "v", str, 6),
+        ]
+    )
+
+    calls.clear()
+    serialized = serde.to_dict(Payload([2, 3.5], {5: 6}))  # type: ignore[dict-item]
+    assert serialized == {"values": [2.0, 3.5], "mapping": {5: "6"}}
+    assert Counter(calls) == Counter(
+        [
+            ("Payload", "v", float, 2),
+            ("Payload", "v", float, 3.5),
+            ("Payload", "k", int, 5),
+            ("Payload", "v", str, 6),
+        ]
+    )
+
+
+def test_custom_coercer_applies_to_optional_values() -> None:
+    @serde.serde(type_check=serde.coerce(coercer=_integer_only_coercer))
+    class Config:
+        scale: float | None
+
+    assert serde.from_dict(Config, {"scale": 4}) == Config(4.0)
+    assert serde.to_dict(Config(4)) == {"scale": 4.0}
+    assert serde.from_dict(Config, {"scale": None}) == Config(None)
+    assert serde.to_dict(Config(None)) == {"scale": None}
+
+
+def test_custom_field_converters_take_precedence_over_custom_coercer() -> None:
+    calls: list[tuple[str, Any]] = []
+
+    def record_call(_owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        calls.append((field_name, value))
+        return target(value)
+
+    @serde.serde(type_check=serde.coerce(coercer=record_call))
+    class Config:
+        serializer_only: int = serde.field(serializer=lambda value: f"serialized:{value}")
+        deserializer_only: int = serde.field(deserializer=lambda _value: 7)
+        plain: int
+
+    config = serde.from_dict(
+        Config,
+        {
+            "serializer_only": "1",
+            "deserializer_only": "ignored",
+            "plain": "3",
+        },
+    )
+    assert config == Config(1, 7, 3)
+    assert Counter(calls) == Counter(
+        [
+            ("serializer_only", "1"),
+            ("plain", "3"),
+        ]
+    )
+
+    calls.clear()
+    assert serde.to_dict(Config("4", "5", "6")) == {  # type: ignore[arg-type]
+        "serializer_only": "serialized:4",
+        "deserializer_only": 5,
+        "plain": 6,
+    }
+    assert Counter(calls) == Counter(
+        [
+            ("deserializer_only", "5"),
+            ("plain", "6"),
+        ]
+    )
+
+
+def test_custom_coercer_does_not_handle_unions() -> None:
+    def fail_if_called(
+        _owner: str | None, _field_name: str, _target: type[Any], _value: Any
+    ) -> Any:
+        raise AssertionError("custom coercer must not be called")
+
+    @serde.serde(type_check=serde.coerce(coercer=fail_if_called))
+    class Choice:
+        value: Union[int, str]
+
+    assert serde.from_dict(Choice, {"value": "1"}) == Choice("1")
+    assert serde.to_dict(Choice("1")) == {"value": "1"}
+
+
+def test_nested_dataclass_uses_its_own_custom_coercer() -> None:
+    outer_calls: list[tuple[str | None, str, type[Any], Any]] = []
+    inner_calls: list[tuple[str | None, str, type[Any], Any]] = []
+
+    def outer_coercer(owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        outer_calls.append((owner, field_name, target, value))
+        return target(value)
+
+    def inner_coercer(owner: str | None, field_name: str, target: type[Any], value: Any) -> Any:
+        inner_calls.append((owner, field_name, target, value))
+        return target(value)
+
+    @serde.serde(type_check=serde.coerce(coercer=inner_coercer))
+    class Inner:
+        value: int
+
+    @serde.serde(type_check=serde.coerce(coercer=outer_coercer))
+    class Outer:
+        inner: Inner
+
+    assert serde.from_dict(Outer, {"inner": {"value": "1"}}) == Outer(Inner(1))
+    assert outer_calls == []
+    assert inner_calls == [("Inner", "value", int, "1")]
+
+    inner_calls.clear()
+    assert serde.to_dict(Outer(Inner("2"))) == {"inner": {"value": 2}}  # type: ignore[arg-type]
+    assert outer_calls == []
+    assert inner_calls == [("Inner", "value", int, "2")]
+
+
+def test_custom_coercer_wraps_deserialization_rejection() -> None:
+    @serde.serde(type_check=serde.coerce(coercer=_integer_only_coercer))
+    class Config:
+        count: int
+
+    with pytest.raises(
+        serde.SerdeError,
+        match=r"failed to coerce the field Config\.count.*expected an integer",
+    ):
+        serde.from_dict(Config, {"count": 3.9999})
+
+
+def test_custom_coercer_wraps_serialization_rejection() -> None:
+    @serde.serde(type_check=serde.coerce(coercer=_integer_only_coercer))
+    class Config:
+        count: int
+
+    with pytest.raises(
+        serde.SerdeError,
+        match=r"failed to coerce the field Config\.count.*expected an integer",
+    ):
+        serde.to_dict(Config(3.9999))  # type: ignore[arg-type]


### PR DESCRIPTION
Allow `coerce` to use custom rules for rejecting or customizing conversions.

Closes #779