### PR TITLE
fix: unwrap PEP 695 type aliases in iter_literals

### DIFF
--- a/serde/compat.py
+++ b/serde/compat.py
@@ -466,6 +466,8 @@ def iter_literals(cls: type[Any]) -> list[TypeLike]:
         if is_union(cls):
             for arg in type_args(cls):
                 recursive(arg)
+        elif is_pep695_type_alias(cls):
+            recursive(cls.__value__)
         if is_dataclass(cls):
             stack.append(cls)
             if isinstance(cls, type):

--- a/tests/test_type_alias.py
+++ b/tests/test_type_alias.py
@@ -109,6 +109,26 @@ class Baz:
     assert value == from_dict(BazClass, to_dict(value))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason=_PEP695_REASON)
+def test_pep695_type_alias_literal() -> None:
+    ns: dict[str, object] = {"serde": serde, "Literal": typing.Literal}
+    exec(
+        """
+type Mode = Literal["trailing", "mean-reversion"]
+
+@serde
+class Foo:
+    value: Mode
+""",
+        ns,
+    )
+    FooClass = typing.cast(type, ns["Foo"])
+
+    value = FooClass("trailing")
+    assert {"value": "trailing"} == to_dict(value)
+    assert value == from_dict(FooClass, {"value": "trailing"})
+
+
 def test_typealiastype_list() -> None:
     @serde
     class Foo:


### PR DESCRIPTION
Closes #782

`iter_unions` unwraps PEP 695 aliases via `is_pep695_type_alias`, but `iter_literals` does not, so a `type Mode = Literal["a", "b"]` field never had its literal deserializer generated and `from_json` failed with "missing required field". Added the same unwrapping branch, plus a regression test beside the existing PEP 695 alias tests (fails without the fix, passes with it).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
