### PR TITLE
Recognize ClassVar when detecting dataclasses

### DIFF
--- a/serde/core.py
+++ b/serde/core.py
@@ -1090,14 +1090,16 @@ def should_impl_dataclass(cls: type[Any]) -> bool:
     # Checking is_dataclass is not enough in such a case that the class is inherited
     # from another dataclass. To do it correctly, check if all fields in __annotations__
     # are present as dataclass fields.
-    annotations = getattr(cls, "__annotations__", {})
-    if not annotations:
+    raw_annotations = getattr(cls, "__annotations__", {})
+    if not raw_annotations:
         return False
 
+    resolved_annotations = get_type_hints(cls)
     field_names = [field.name for field in dataclass_fields(cls)]
-    for field_name, annotation in annotations.items():
-        # Omit InitVar field because it doesn't appear in dataclass fields.
-        if is_instance(annotation, dataclasses.InitVar):
+    for field_name, raw_annotation in raw_annotations.items():
+        annotation = resolved_annotations.get(field_name, raw_annotation)
+        # Omit InitVar and ClassVar fields because they don't appear in dataclass fields.
+        if is_instance(annotation, dataclasses.InitVar) or is_class_var(annotation):
             continue
         # This field in __annotations__ is not a part of dataclass fields.
         # This means this class does not implement dataclass directly.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
+from typing import ClassVar
 
 from serde.core import should_impl_dataclass
 
@@ -79,3 +80,12 @@ def test_should_impl_dataclass() -> None:
     assert not should_impl_dataclass(Base1)
     assert not should_impl_dataclass(Base6)
     assert should_impl_dataclass(Derived6)
+
+
+def test_should_impl_dataclass_with_class_var() -> None:
+    @dataclass
+    class Base:
+        values: list[int] = field(default_factory=lambda: [1])
+        namespace: ClassVar[str | None] = None
+
+    assert not should_impl_dataclass(Base)

--- a/tests/test_lazy_type_evaluation.py
+++ b/tests/test_lazy_type_evaluation.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # this is the line this test file is all abo
 
 import dataclasses
 from enum import Enum
+from typing import ClassVar
 
 import pytest
 
@@ -41,6 +42,21 @@ def test_serde_with_lazy_type_annotations() -> None:
 
     assert b == from_dict(B, b_dict)
     assert b_dict == to_dict(b)
+
+
+def test_serde_with_class_var() -> None:
+    @serde
+    @dataclasses.dataclass
+    class Base:
+        values: list[int] = dataclasses.field(default_factory=lambda: [1])
+        namespace: ClassVar[str | None] = None
+
+    @serde
+    @dataclasses.dataclass
+    class Child(Base):
+        child: int = 2
+
+    assert from_dict(Child, {}) == Child(values=[1], child=2)
 
 
 # test_forward_reference_works currently only works with global visible classes


### PR DESCRIPTION
`ClassVar` annotations are excluded from `dataclasses.fields()`, so ignore them when deciding whether a class still needs the dataclass decorator applied.

Before this change, the following code will raise an error because `pyserde` decorates the dataclass again:

```python
# With or without deferred annoations
# from __future__ import annotations

from dataclasses import dataclass, field, fields
from typing import ClassVar
import serde


@serde.serde
@dataclass
class Base:
    values: list[int] = field(default_factory=lambda: [1])
    namespace: ClassVar[str | None] = None


@serde.serde
class Child(Base):
    child: int = 2


Child = serde.serde(Child)
print([(item.name, item.default_factory) for item in fields(Child)])
print(serde.from_dict(Child, {}))
```

Old behavior:

```
[('values', <dataclasses._MISSING_TYPE object at 0x10592cec0>), ('child', <dataclasses._MISSING_TYPE object at 0x10592cec0>)]
Traceback (most recent call last):
  File "/tmp/pyserde_bug.py", line 20, in <module>
    print(serde.from_dict(Child, {}))
          ~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "./pyserde/serde/de.py", line 690, in from_dict
    return from_obj(
        cls,
    ...<3 lines>...
        deserialize_numbers=deserialize_numbers,
    )
  File "./pyserde/serde/de.py", line 640, in from_obj
    raise SerdeError(e) from None
serde.compat.SerdeError: missing required field 'values' while deserializing Child
```

Expected result & new behavior:

```
[('values', <function Base.<lambda> at 0x103d36c00>), ('child', <dataclasses._MISSING_TYPE object at 0x10324cec0>)]
Child(values=[1], child=2)
```